### PR TITLE
Updated NZ locality name

### DIFF
--- a/data/101/915/123/101915123.geojson
+++ b/data/101/915/123/101915123.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.000061,
-    "geom:area_square_m":617751.024181,
+    "geom:area_square_m":617751.024176,
     "geom:bbox":"174.078820249,-35.2944933279,174.10021716,-35.2754269409",
     "geom:latitude":-35.285305,
     "geom:longitude":174.09092,
@@ -27,6 +27,9 @@
         "Paihia"
     ],
     "name:eng_x_preferred":[
+        "Paihia"
+    ],
+    "name:eng_x_variant":[
         "Pahia"
     ],
     "name:fre_x_preferred":[
@@ -94,8 +97,8 @@
         }
     ],
     "wof:id":101915123,
-    "wof:lastmodified":1527643142,
-    "wof:name":"Pahia",
+    "wof:lastmodified":1561492597,
+    "wof:name":"Paihia",
     "wof:parent_id":102079255,
     "wof:placetype":"locality",
     "wof:population":1944,


### PR DESCRIPTION
Fixes https://github.com/whosonfirst-data/whosonfirst-data/issues/1643

- Updated `name:eng_x_*` properties
- Updated `wof:name` value

No PIP work, can merge once approved.