### PR TITLE
Remove superseded_by value on current localities

### DIFF
--- a/data/101/914/257/101914257.geojson
+++ b/data/101/914/257/101914257.geojson
@@ -429,11 +429,11 @@
     "wd:population":1454300,
     "wd:wordcount":9046,
     "wof:belongsto":[
-        85687243,
         102191583,
-        1729238453,
         85633345,
-        102079403
+        102079403,
+        1729238453,
+        85687243
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -467,16 +467,14 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1603235722,
+    "wof:lastmodified":1603394467,
     "wof:name":"Auckland",
     "wof:parent_id":1729238453,
     "wof:placetype":"locality",
     "wof:population":1454300,
     "wof:population_rank":12,
     "wof:repo":"whosonfirst-data-admin-nz",
-    "wof:superseded_by":[
-        1729238453
-    ],
+    "wof:superseded_by":[],
     "wof:supersedes":[
         101914333,
         101914387,

--- a/data/101/914/269/101914269.geojson
+++ b/data/101/914/269/101914269.geojson
@@ -298,11 +298,11 @@
     "wd:longitude":170.5,
     "wd:wordcount":8479,
     "wof:belongsto":[
-        85687201,
         102191583,
-        1729238495,
         85633345,
-        102079387
+        102079387,
+        1729238495,
+        85687201
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -338,16 +338,14 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1603235723,
+    "wof:lastmodified":1603394470,
     "wof:name":"Dunedin",
     "wof:parent_id":1729238495,
     "wof:placetype":"locality",
     "wof:population":114347,
     "wof:population_rank":9,
     "wof:repo":"whosonfirst-data-admin-nz",
-    "wof:superseded_by":[
-        1729238495
-    ],
+    "wof:superseded_by":[],
     "wof:supersedes":[
         101914509,
         101914617,

--- a/data/101/914/271/101914271.geojson
+++ b/data/101/914/271/101914271.geojson
@@ -389,11 +389,11 @@
     ],
     "src:lbl_centroid":"mapshaper",
     "wof:belongsto":[
-        85687229,
         102191583,
-        1729238493,
         85633345,
-        102079271
+        102079271,
+        1729238493,
+        85687229
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -428,14 +428,12 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1603235724,
+    "wof:lastmodified":1603394474,
     "wof:name":"Hamilton",
     "wof:parent_id":1729238493,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-nz",
-    "wof:superseded_by":[
-        1729238493
-    ],
+    "wof:superseded_by":[],
     "wof:supersedes":[
         101914369,
         101914373,

--- a/data/101/914/285/101914285.geojson
+++ b/data/101/914/285/101914285.geojson
@@ -519,11 +519,11 @@
     "src:lbl_centroid":"mapshaper",
     "src:population":"geonames",
     "wof:belongsto":[
-        85687233,
         102191583,
-        1729238583,
         85633345,
-        102079339
+        102079339,
+        1729238583,
+        85687233
     ],
     "wof:breaches":[],
     "wof:capital_of":85633345,
@@ -561,16 +561,14 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1603235724,
+    "wof:lastmodified":1603394477,
     "wof:name":"Wellington",
     "wof:parent_id":1729238583,
     "wof:placetype":"locality",
     "wof:population":381900,
     "wof:population_rank":10,
     "wof:repo":"whosonfirst-data-admin-nz",
-    "wof:superseded_by":[
-        1729238583
-    ],
+    "wof:superseded_by":[],
     "wof:supersedes":[
         101914341,
         101914343,

--- a/data/101/914/521/101914521.geojson
+++ b/data/101/914/521/101914521.geojson
@@ -389,11 +389,11 @@
     "wd:population":362000,
     "wd:wordcount":8478,
     "wof:belongsto":[
-        85687179,
         102191583,
-        1729238507,
         85633345,
-        102079401
+        102079401,
+        1729238507,
+        85687179
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -430,7 +430,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1603235723,
+    "wof:lastmodified":1603394480,
     "wof:megacity":0,
     "wof:name":"Christchurch",
     "wof:parent_id":1729238507,
@@ -439,9 +439,7 @@
     "wof:population_rank":10,
     "wof:repo":"whosonfirst-data-admin-nz",
     "wof:scale":3,
-    "wof:superseded_by":[
-        1729238507
-    ],
+    "wof:superseded_by":[],
     "wof:supersedes":[
         101914709,
         101914711,


### PR DESCRIPTION
This is a follow up to https://github.com/whosonfirst-data/whosonfirst-data-admin-nz/pull/12

This PR corrects five locality records by removing the id from the record's `wof:superseded_by` properties. These properties were iterated on through #12, but five records didn't have the value removed before that PR was merged. No PIP work needed.