### PR TITLE
Flag admin1 capitals

### DIFF
--- a/data/101/914/253/101914253.geojson
+++ b/data/101/914/253/101914253.geojson
@@ -241,6 +241,7 @@
         85687149
     ],
     "wof:breaches":[],
+    "wof:capital_of":85687149,
     "wof:concordances":{
         "fct:id":"020adf9e-8f76-11e1-848f-cfd5bf3ef515",
         "gn:id":6230919,
@@ -276,7 +277,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1603230346,
+    "wof:lastmodified":1607124817,
     "wof:name":"Whangarei",
     "wof:parent_id":1729238617,
     "wof:placetype":"locality",

--- a/data/101/914/257/101914257.geojson
+++ b/data/101/914/257/101914257.geojson
@@ -436,6 +436,7 @@
         85687243
     ],
     "wof:breaches":[],
+    "wof:capital_of":85687243,
     "wof:concordances":{
         "gn:id":2193733,
         "wd:id":"Q37100"
@@ -467,7 +468,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1603394467,
+    "wof:lastmodified":1607124825,
     "wof:name":"Auckland",
     "wof:parent_id":1729238453,
     "wof:placetype":"locality",

--- a/data/101/914/259/101914259.geojson
+++ b/data/101/914/259/101914259.geojson
@@ -260,6 +260,7 @@
         85687251
     ],
     "wof:breaches":[],
+    "wof:capital_of":85687251,
     "wof:concordances":{
         "fct:id":"020dfbf2-8f76-11e1-848f-cfd5bf3ef515",
         "gn:id":2185018,
@@ -295,7 +296,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1603230311,
+    "wof:lastmodified":1607124825,
     "wof:name":"Palmerston North",
     "wof:parent_id":1729238575,
     "wof:placetype":"locality",

--- a/data/101/914/269/101914269.geojson
+++ b/data/101/914/269/101914269.geojson
@@ -305,6 +305,7 @@
         85687201
     ],
     "wof:breaches":[],
+    "wof:capital_of":85687201,
     "wof:concordances":{
         "fct:id":"020dfa08-8f76-11e1-848f-cfd5bf3ef515",
         "gn:id":2191562,
@@ -338,7 +339,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1603394470,
+    "wof:lastmodified":1607124822,
     "wof:name":"Dunedin",
     "wof:parent_id":1729238495,
     "wof:placetype":"locality",

--- a/data/101/914/271/101914271.geojson
+++ b/data/101/914/271/101914271.geojson
@@ -396,6 +396,7 @@
         85687229
     ],
     "wof:breaches":[],
+    "wof:capital_of":85687229,
     "wof:concordances":{
         "gp:id":91502809,
         "wd:id":"Q200028"
@@ -428,7 +429,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1603394474,
+    "wof:lastmodified":1607124824,
     "wof:name":"Hamilton",
     "wof:parent_id":1729238493,
     "wof:placetype":"locality",

--- a/data/101/914/285/101914285.geojson
+++ b/data/101/914/285/101914285.geojson
@@ -561,7 +561,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1603394477,
+    "wof:lastmodified":1607124824,
     "wof:name":"Wellington",
     "wof:parent_id":1729238583,
     "wof:placetype":"locality",

--- a/data/101/914/293/101914293.geojson
+++ b/data/101/914/293/101914293.geojson
@@ -98,10 +98,11 @@
     "wof:belongsto":[
         102191583,
         85633345,
-        85687195,
-        102079293
+        102079293,
+        85687195
     ],
     "wof:breaches":[],
+    "wof:capital_of":85687195,
     "wof:concordances":{
         "fct:id":"020c6a94-8f76-11e1-848f-cfd5bf3ef515",
         "gn:id":6223846,
@@ -133,7 +134,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1603135896,
+    "wof:lastmodified":1607124821,
     "wof:name":"Stratford",
     "wof:parent_id":102079293,
     "wof:placetype":"locality",

--- a/data/101/914/327/101914327.geojson
+++ b/data/101/914/327/101914327.geojson
@@ -156,6 +156,7 @@
         85687175
     ],
     "wof:breaches":[],
+    "wof:capital_of":85687175,
     "wof:concordances":{
         "fct:id":"020df90e-8f76-11e1-848f-cfd5bf3ef515",
         "gn:id":2208330,
@@ -191,7 +192,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1603230353,
+    "wof:lastmodified":1607124819,
     "wof:name":"Whakatane",
     "wof:parent_id":1729238615,
     "wof:placetype":"locality",

--- a/data/101/914/521/101914521.geojson
+++ b/data/101/914/521/101914521.geojson
@@ -396,6 +396,7 @@
         85687179
     ],
     "wof:breaches":[],
+    "wof:capital_of":85687179,
     "wof:concordances":{
         "fct:id":"020dfada-8f76-11e1-848f-cfd5bf3ef515",
         "gn:id":2192362,
@@ -430,7 +431,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1603394480,
+    "wof:lastmodified":1607124819,
     "wof:megacity":0,
     "wof:name":"Christchurch",
     "wof:parent_id":1729238507,

--- a/data/101/914/591/101914591.geojson
+++ b/data/101/914/591/101914591.geojson
@@ -238,6 +238,7 @@
         85687237
     ],
     "wof:breaches":[],
+    "wof:capital_of":85687237,
     "wof:concordances":{
         "fct:id":"020b0ca8-8f76-11e1-848f-cfd5bf3ef515",
         "gn:id":2206854,
@@ -273,7 +274,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1603230333,
+    "wof:lastmodified":1607124824,
     "wof:name":"Gisborne",
     "wof:parent_id":1729238487,
     "wof:placetype":"locality",

--- a/data/101/914/679/101914679.geojson
+++ b/data/101/914/679/101914679.geojson
@@ -298,6 +298,7 @@
         1729238511
     ],
     "wof:breaches":[],
+    "wof:capital_of":85687189,
     "wof:concordances":{
         "fct:id":"020dda14-8f76-11e1-848f-cfd5bf3ef515",
         "gn:id":2186313,
@@ -324,7 +325,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1603135078,
+    "wof:lastmodified":1607124821,
     "wof:name":"Napier",
     "wof:parent_id":1729238511,
     "wof:placetype":"locality",

--- a/data/101/914/855/101914855.geojson
+++ b/data/101/914/855/101914855.geojson
@@ -113,6 +113,7 @@
         85687219
     ],
     "wof:breaches":[],
+    "wof:capital_of":85687219,
     "wof:concordances":{
         "gp:id":2350407,
         "nz-linz:id":2538,
@@ -145,7 +146,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1603230350,
+    "wof:lastmodified":1607124823,
     "wof:name":"Richmond",
     "wof:parent_id":1729238447,
     "wof:placetype":"locality",

--- a/data/101/915/333/101915333.geojson
+++ b/data/101/915/333/101915333.geojson
@@ -145,6 +145,7 @@
         85687165
     ],
     "wof:breaches":[],
+    "wof:capital_of":85687165,
     "wof:concordances":{
         "fct:id":"020dd62c-8f76-11e1-848f-cfd5bf3ef515",
         "gn:id":2206895,
@@ -180,7 +181,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1603230267,
+    "wof:lastmodified":1607124817,
     "wof:name":"Greymouth",
     "wof:parent_id":1729238491,
     "wof:placetype":"locality",

--- a/data/101/915/515/101915515.geojson
+++ b/data/101/915/515/101915515.geojson
@@ -243,6 +243,7 @@
         85687211
     ],
     "wof:breaches":[],
+    "wof:capital_of":85687211,
     "wof:concordances":{
         "fct:id":"0211ad38-8f76-11e1-848f-cfd5bf3ef515",
         "gn:id":2189529,
@@ -278,7 +279,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1603230285,
+    "wof:lastmodified":1607124822,
     "wof:name":"Invercargill",
     "wof:parent_id":1729238483,
     "wof:placetype":"locality",

--- a/data/101/915/555/101915555.geojson
+++ b/data/101/915/555/101915555.geojson
@@ -337,6 +337,7 @@
         85687157
     ],
     "wof:breaches":[],
+    "wof:capital_of":85687157,
     "wof:concordances":{
         "fct:id":"020df9a4-8f76-11e1-848f-cfd5bf3ef515",
         "gn:id":2184360,
@@ -374,7 +375,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1603230263,
+    "wof:lastmodified":1607124817,
     "wof:name":"Nelson",
     "wof:parent_id":1729238513,
     "wof:placetype":"locality",

--- a/data/101/915/709/101915709.geojson
+++ b/data/101/915/709/101915709.geojson
@@ -200,6 +200,7 @@
         85687185
     ],
     "wof:breaches":[],
+    "wof:capital_of":85687185,
     "wof:concordances":{
         "fct:id":"020deb80-8f76-11e1-848f-cfd5bf3ef515",
         "gn:id":6243926,
@@ -237,7 +238,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1603230242,
+    "wof:lastmodified":1607124820,
     "wof:name":"Blenheim",
     "wof:parent_id":1729238455,
     "wof:placetype":"locality",

--- a/data/856/871/49/85687149.geojson
+++ b/data/856/871/49/85687149.geojson
@@ -297,6 +297,9 @@
         85633345
     ],
     "wof:breaches":[],
+    "wof:capital":[
+        101914253
+    ],
     "wof:concordances":{
         "digitalenvoy:region_code":25049,
         "fips:code":"NZF6",
@@ -325,7 +328,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1603229389,
+    "wof:lastmodified":1607124817,
     "wof:name":"Northland Region",
     "wof:parent_id":85633345,
     "wof:placetype":"region",

--- a/data/856/871/57/85687157.geojson
+++ b/data/856/871/57/85687157.geojson
@@ -86,6 +86,9 @@
         85633345
     ],
     "wof:breaches":[],
+    "wof:capital":[
+        101915555
+    ],
     "wof:concordances":{
         "digitalenvoy:region_code":25048,
         "fips:code":"NZF5",
@@ -110,7 +113,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1603191938,
+    "wof:lastmodified":1607124817,
     "wof:name":"Nelson Region",
     "wof:parent_id":85633345,
     "wof:placetype":"region",

--- a/data/856/871/65/85687165.geojson
+++ b/data/856/871/65/85687165.geojson
@@ -233,6 +233,9 @@
         85633345
     ],
     "wof:breaches":[],
+    "wof:capital":[
+        101915333
+    ],
     "wof:concordances":{
         "digitalenvoy:region_code":25056,
         "fips:code":"NZG3",
@@ -259,7 +262,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1603229385,
+    "wof:lastmodified":1607124818,
     "wof:name":"West Coast Region",
     "wof:parent_id":85633345,
     "wof:placetype":"region",

--- a/data/856/871/75/85687175.geojson
+++ b/data/856/871/75/85687175.geojson
@@ -236,6 +236,9 @@
         85633345
     ],
     "wof:breaches":[],
+    "wof:capital":[
+        101914327
+    ],
     "wof:concordances":{
         "digitalenvoy:region_code":25042,
         "fips:code":"NZE8",
@@ -262,7 +265,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1603229384,
+    "wof:lastmodified":1607124819,
     "wof:name":"Bay of Plenty Region",
     "wof:parent_id":85633345,
     "wof:placetype":"region",

--- a/data/856/871/79/85687179.geojson
+++ b/data/856/871/79/85687179.geojson
@@ -334,6 +334,9 @@
         85633345
     ],
     "wof:breaches":[],
+    "wof:capital":[
+        101914521
+    ],
     "wof:concordances":{
         "digitalenvoy:region_code":25043,
         "fips:code":"NZE9",
@@ -362,7 +365,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1603229386,
+    "wof:lastmodified":1607124819,
     "wof:name":"Canterbury Region",
     "wof:parent_id":85633345,
     "wof:placetype":"region",

--- a/data/856/871/85/85687185.geojson
+++ b/data/856/871/85/85687185.geojson
@@ -285,6 +285,9 @@
         85633345
     ],
     "wof:breaches":[],
+    "wof:capital":[
+        101915709
+    ],
     "wof:concordances":{
         "digitalenvoy:region_code":25046,
         "fips:code":"NZF4",
@@ -312,7 +315,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1603229388,
+    "wof:lastmodified":1607124820,
     "wof:name":"Marlborough Region",
     "wof:parent_id":85633345,
     "wof:placetype":"region",

--- a/data/856/871/89/85687189.geojson
+++ b/data/856/871/89/85687189.geojson
@@ -223,6 +223,9 @@
         85633345
     ],
     "wof:breaches":[],
+    "wof:capital":[
+        101914679
+    ],
     "wof:concordances":{
         "digitalenvoy:region_code":25045,
         "fips:code":"NZF2",
@@ -248,7 +251,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1603229383,
+    "wof:lastmodified":1607124821,
     "wof:name":"Hawke's Bay Region",
     "wof:parent_id":85633345,
     "wof:placetype":"region",

--- a/data/856/871/95/85687195.geojson
+++ b/data/856/871/95/85687195.geojson
@@ -278,6 +278,9 @@
         85633345
     ],
     "wof:breaches":[],
+    "wof:capital":[
+        101914293
+    ],
     "wof:concordances":{
         "digitalenvoy:region_code":25053,
         "fips:code":"NZF9",
@@ -306,7 +309,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1603229382,
+    "wof:lastmodified":1607124821,
     "wof:name":"Taranaki Region",
     "wof:parent_id":85633345,
     "wof:placetype":"region",

--- a/data/856/872/01/85687201.geojson
+++ b/data/856/872/01/85687201.geojson
@@ -284,6 +284,9 @@
         85633345
     ],
     "wof:breaches":[],
+    "wof:capital":[
+        101914269
+    ],
     "wof:concordances":{
         "digitalenvoy:region_code":25050,
         "fips:code":"NZF7",
@@ -312,7 +315,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1603229375,
+    "wof:lastmodified":1607124822,
     "wof:name":"Otago Region",
     "wof:parent_id":85633345,
     "wof:placetype":"region",

--- a/data/856/872/11/85687211.geojson
+++ b/data/856/872/11/85687211.geojson
@@ -288,6 +288,9 @@
         85633345
     ],
     "wof:breaches":[],
+    "wof:capital":[
+        101915515
+    ],
     "wof:concordances":{
         "digitalenvoy:region_code":25051,
         "fips:code":"NZF8",
@@ -316,7 +319,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1603229373,
+    "wof:lastmodified":1607124822,
     "wof:name":"Southland Region",
     "wof:parent_id":85633345,
     "wof:placetype":"region",

--- a/data/856/872/19/85687219.geojson
+++ b/data/856/872/19/85687219.geojson
@@ -123,6 +123,9 @@
         85633345
     ],
     "wof:breaches":[],
+    "wof:capital":[
+        101914855
+    ],
     "wof:concordances":{
         "digitalenvoy:region_code":25052,
         "fips:code":"NZG4",
@@ -149,7 +152,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1603198335,
+    "wof:lastmodified":1607124823,
     "wof:name":"Tasman Region",
     "wof:parent_id":85633345,
     "wof:placetype":"region",

--- a/data/856/872/29/85687229.geojson
+++ b/data/856/872/29/85687229.geojson
@@ -308,6 +308,9 @@
         85633345
     ],
     "wof:breaches":[],
+    "wof:capital":[
+        101914271
+    ],
     "wof:concordances":{
         "digitalenvoy:region_code":25055,
         "fips:code":"NZG1",
@@ -336,7 +339,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1603229373,
+    "wof:lastmodified":1607124824,
     "wof:name":"Waikato Region",
     "wof:parent_id":85633345,
     "wof:placetype":"region",

--- a/data/856/872/33/85687233.geojson
+++ b/data/856/872/33/85687233.geojson
@@ -413,7 +413,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1603229372,
+    "wof:lastmodified":1607124824,
     "wof:name":"Wellington Region",
     "wof:parent_id":85633345,
     "wof:placetype":"region",

--- a/data/856/872/37/85687237.geojson
+++ b/data/856/872/37/85687237.geojson
@@ -145,6 +145,9 @@
         85633345
     ],
     "wof:breaches":[],
+    "wof:capital":[
+        101914591
+    ],
     "wof:concordances":{
         "digitalenvoy:region_code":25044,
         "fips:code":"NZF1",
@@ -171,7 +174,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1603199065,
+    "wof:lastmodified":1607124824,
     "wof:name":"Gisborne Region",
     "wof:parent_id":85633345,
     "wof:placetype":"region",

--- a/data/856/872/43/85687243.geojson
+++ b/data/856/872/43/85687243.geojson
@@ -242,6 +242,9 @@
         85633345
     ],
     "wof:breaches":[],
+    "wof:capital":[
+        101914257
+    ],
     "wof:concordances":{
         "digitalenvoy:region_code":25041,
         "fips:code":"NZE7",
@@ -268,7 +271,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1603229374,
+    "wof:lastmodified":1607124825,
     "wof:name":"Auckland Region",
     "wof:parent_id":85633345,
     "wof:placetype":"region",

--- a/data/856/872/51/85687251.geojson
+++ b/data/856/872/51/85687251.geojson
@@ -291,6 +291,9 @@
         85633345
     ],
     "wof:breaches":[],
+    "wof:capital":[
+        101914259
+    ],
     "wof:concordances":{
         "digitalenvoy:region_code":25047,
         "fips:code":"NZF3",
@@ -319,7 +322,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1603229371,
+    "wof:lastmodified":1607124825,
     "wof:name":"Manawatu-Wanganui Region",
     "wof:parent_id":85633345,
     "wof:placetype":"region",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/58

This PR:

- Adds `wof:capital` to admin1 records, equal to the `wof:id` of the admin1's capital locality
- Adds `wof:capital_of` to locality records, equal to the `wof:id` of the parent admin1
- Validates changes

Can be merged once approved.