### PR TITLE
Update properties of megacities

### DIFF
--- a/data/101/914/257/101914257.geojson
+++ b/data/101/914/257/101914257.geojson
@@ -21,7 +21,7 @@
     "mz:hierarchy_label":1,
     "mz:is_current":1,
     "mz:is_funky":0,
-    "mz:min_zoom":4.0,
+    "mz:min_zoom":3.0,
     "name:afr_x_preferred":[
         "Auckland"
     ],
@@ -441,6 +441,7 @@
     ],
     "wof:concordances":{
         "gn:id":2193733,
+        "ne:id":1159151703,
         "wd:id":"Q37100"
     },
     "wof:coterminous":[
@@ -470,7 +471,8 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1607462738,
+    "wof:lastmodified":1608688194,
+    "wof:megacity":1,
     "wof:name":"Auckland",
     "wof:parent_id":1729238453,
     "wof:placetype":"locality",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1547

- Updates megacity records with new:
  - concordances
  - names (if not already present)
  - label centroids
  - megacity flags
- Updates geometries of any megacity record with a `Point` geometry
- Updates parent geometries when necessary