### PR TITLE
Update five non nz-linz localities

### DIFF
--- a/data/101/914/319/101914319.geojson
+++ b/data/101/914/319/101914319.geojson
@@ -3,6 +3,7 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2021-01-21",
     "edtf:inception":"uuuu",
     "geom:area":0.001643,
     "geom:area_square_m":15282505.958205,
@@ -19,7 +20,7 @@
     "mps:latitude":-41.208196,
     "mps:longitude":174.912578,
     "mz:hierarchy_label":1,
-    "mz:is_current":1,
+    "mz:is_current":0,
     "mz:is_funky":0,
     "mz:min_zoom":7.0,
     "name:ara_x_preferred":[
@@ -219,11 +220,11 @@
     "wd:population":102000,
     "wd:wordcount":2727,
     "wof:belongsto":[
-        85687233,
         102191583,
-        1729238533,
         85633345,
-        102079337
+        102079337,
+        1729238533,
+        85687233
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -260,14 +261,16 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1603235725,
+    "wof:lastmodified":1611269633,
     "wof:name":"Lower Hutt",
     "wof:parent_id":1729238533,
     "wof:placetype":"locality",
     "wof:population":102000,
     "wof:population_rank":9,
     "wof:repo":"whosonfirst-data-admin-nz",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1729238533
+    ],
     "wof:supersedes":[
         101914351,
         101914519,

--- a/data/101/915/063/101915063.geojson
+++ b/data/101/915/063/101915063.geojson
@@ -3,6 +3,7 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2021-01-21",
     "edtf:inception":"uuuu",
     "geom:area":0.000077,
     "geom:area_square_m":742339.409609,
@@ -17,8 +18,8 @@
     "mps:latitude":-39.114582,
     "mps:longitude":173.953353,
     "mz:hierarchy_label":0,
-    "mz:is_current":1,
-    "mz:is_funky":1,
+    "mz:is_current":0,
+    "mz:is_funky":0,
     "mz:min_zoom":12.0,
     "name:ceb_x_preferred":[
         "Oakura"
@@ -89,7 +90,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1603230253,
+    "wof:lastmodified":1611269636,
     "wof:name":"Oakura",
     "wof:parent_id":102079311,
     "wof:placetype":"locality",

--- a/data/101/915/887/101915887.geojson
+++ b/data/101/915/887/101915887.geojson
@@ -3,6 +3,7 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2021-01-21",
     "edtf:inception":"uuuu",
     "geom:area":0.000025,
     "geom:area_square_m":222953.373084,
@@ -17,8 +18,8 @@
     "mps:latitude":-43.210972,
     "mps:longitude":172.751788,
     "mz:hierarchy_label":0,
-    "mz:is_current":1,
-    "mz:is_funky":1,
+    "mz:is_current":0,
+    "mz:is_funky":0,
     "mz:min_zoom":12.0,
     "name:bul_x_preferred":[
         "\u041b\u0435\u0438\u0442\u0445\u0444\u0438\u0435\u043b\u0434"
@@ -95,7 +96,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1603230246,
+    "wof:lastmodified":1611269640,
     "wof:name":"Leithfield Beach",
     "wof:parent_id":102079365,
     "wof:placetype":"locality",

--- a/data/101/916/599/101916599.geojson
+++ b/data/101/916/599/101916599.geojson
@@ -3,6 +3,7 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2021-01-21",
     "edtf:inception":"uuuu",
     "geom:area":0.000022,
     "geom:area_square_m":214740.554733,
@@ -17,8 +18,8 @@
     "mps:latitude":-37.634518,
     "mps:longitude":176.180064,
     "mz:hierarchy_label":0,
-    "mz:is_current":1,
-    "mz:is_funky":1,
+    "mz:is_current":0,
+    "mz:is_funky":0,
     "mz:min_zoom":12.0,
     "name:afr_x_preferred":[
         "Mount Maunganui"
@@ -300,7 +301,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1603230383,
+    "wof:lastmodified":1611269644,
     "wof:name":"Mount Maunganui",
     "wof:parent_id":102079285,
     "wof:placetype":"locality",

--- a/data/101/918/677/101918677.geojson
+++ b/data/101/918/677/101918677.geojson
@@ -3,6 +3,7 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2021-01-21",
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":3139.999022,
@@ -17,8 +18,8 @@
     "mps:latitude":-41.219762,
     "mps:longitude":175.447934,
     "mz:hierarchy_label":0,
-    "mz:is_current":1,
-    "mz:is_funky":1,
+    "mz:is_current":0,
+    "mz:is_funky":0,
     "mz:min_zoom":12.0,
     "name:afr_x_preferred":[
         "Martinborough"
@@ -284,7 +285,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1603230407,
+    "wof:lastmodified":1611269649,
     "wof:name":"Martinorough",
     "wof:parent_id":102079347,
     "wof:placetype":"locality",

--- a/data/172/923/853/3/1729238533.geojson
+++ b/data/172/923/853/3/1729238533.geojson
@@ -246,7 +246,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1603229528,
+    "wof:lastmodified":1611269653,
     "wof:name":"Lower Hutt",
     "wof:parent_id":102079337,
     "wof:placetype":"localadmin",
@@ -254,7 +254,9 @@
     "wof:population_rank":9,
     "wof:repo":"whosonfirst-data-admin-nz",
     "wof:superseded_by":[],
-    "wof:supersedes":[],
+    "wof:supersedes":[
+        101914319
+    ],
     "wof:tags":[]
 },
   "bbox": [


### PR DESCRIPTION
Fixes https://github.com/whosonfirst-data/whosonfirst-data/issues/1920

This PR updates five locality records that were not updated correctly as part of https://github.com/whosonfirst-data/whosonfirst-data-admin-nz/pull/12.

- One "Lower Huitt" locality record was deprecated and superseded into the "Lower Huitt" localadmin, something missed as part of the initial PR.
- Four additional small locality records were deprecated and flagged as not current. These records were updated as part of the initial PR, but flagged with an `mz:is_funky` property, rather than deprecated.

This PR will require PIP work, which I will add as a new commit once approved.