### PR TITLE
NZ concordances, placetype local, and more

### DIFF
--- a/data/102/079/255/102079255.geojson
+++ b/data/102/079/255/102079255.geojson
@@ -136,8 +136,13 @@
     "wof:concordances":{
         "digitalenvoy:metro_code":554010,
         "hasc:id":"NZ.NO.FN",
+        "nz-linz:id":"001",
         "wd:id":"Q1365839"
     },
+    "wof:concordances_official":"nz-linz:id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"NZ",
     "wof:geom_alt":[
         "quattroshapes"
@@ -160,7 +165,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1694639709,
+    "wof:lastmodified":1695886354,
     "wof:name":"Far North District",
     "wof:parent_id":85687149,
     "wof:placetype":"county",

--- a/data/102/079/257/102079257.geojson
+++ b/data/102/079/257/102079257.geojson
@@ -106,8 +106,13 @@
     "wof:concordances":{
         "digitalenvoy:metro_code":554011,
         "hasc:id":"NZ.NO.WN",
+        "nz-linz:id":"002",
         "wd:id":"Q3696415"
     },
+    "wof:concordances_official":"nz-linz:id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"NZ",
     "wof:geom_alt":[
         "quattroshapes"
@@ -130,7 +135,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1694639700,
+    "wof:lastmodified":1695886327,
     "wof:name":"Whangarei District",
     "wof:parent_id":85687149,
     "wof:placetype":"county",

--- a/data/102/079/259/102079259.geojson
+++ b/data/102/079/259/102079259.geojson
@@ -109,8 +109,13 @@
     "wof:concordances":{
         "digitalenvoy:metro_code":554024,
         "hasc:id":"NZ.NO.KP",
+        "nz-linz:id":"003",
         "wd:id":"Q163982"
     },
+    "wof:concordances_official":"nz-linz:id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"NZ",
     "wof:geom_alt":[
         "quattroshapes"
@@ -133,7 +138,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1694639702,
+    "wof:lastmodified":1695886332,
     "wof:name":"Kaipara District",
     "wof:parent_id":85687149,
     "wof:placetype":"county",

--- a/data/102/079/261/102079261.geojson
+++ b/data/102/079/261/102079261.geojson
@@ -118,8 +118,13 @@
     "wof:concordances":{
         "digitalenvoy:metro_code":554043,
         "hasc:id":"NZ.WK.TC",
+        "nz-linz:id":"011",
         "wd:id":"Q2305865"
     },
+    "wof:concordances_official":"nz-linz:id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"NZ",
     "wof:geom_alt":[
         "quattroshapes"
@@ -142,7 +147,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1694639703,
+    "wof:lastmodified":1695886336,
     "wof:name":"Thames-Coromandel District",
     "wof:parent_id":85687229,
     "wof:placetype":"county",

--- a/data/102/079/263/102079263.geojson
+++ b/data/102/079/263/102079263.geojson
@@ -106,8 +106,13 @@
     "wof:concordances":{
         "gp:id":55875879,
         "hasc:id":"NZ.WK.HK",
+        "nz-linz:id":"012",
         "wd:id":"Q1589865"
     },
+    "wof:concordances_official":"nz-linz:id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"NZ",
     "wof:geom_alt":[
         "quattroshapes"
@@ -130,7 +135,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1694639708,
+    "wof:lastmodified":1695886353,
     "wof:name":"Hauraki District",
     "wof:parent_id":85687229,
     "wof:placetype":"county",

--- a/data/102/079/265/102079265.geojson
+++ b/data/102/079/265/102079265.geojson
@@ -108,8 +108,13 @@
     "wof:breaches":[],
     "wof:concordances":{
         "hasc:id":"NZ.WK.WT",
+        "nz-linz:id":"013",
         "wd:id":"Q1973593"
     },
+    "wof:concordances_official":"nz-linz:id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"NZ",
     "wof:geom_alt":[
         "quattroshapes"
@@ -132,7 +137,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1694639708,
+    "wof:lastmodified":1695886351,
     "wof:name":"Waikato District",
     "wof:parent_id":85687229,
     "wof:placetype":"county",

--- a/data/102/079/267/102079267.geojson
+++ b/data/102/079/267/102079267.geojson
@@ -118,8 +118,13 @@
     "wof:concordances":{
         "digitalenvoy:metro_code":554044,
         "hasc:id":"NZ.WK.MP",
+        "nz-linz:id":"015",
         "wd:id":"Q974296"
     },
+    "wof:concordances_official":"nz-linz:id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"NZ",
     "wof:geom_alt":[
         "quattroshapes"
@@ -142,7 +147,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1694639705,
+    "wof:lastmodified":1695886340,
     "wof:name":"Matamata-Piako District",
     "wof:parent_id":85687229,
     "wof:placetype":"county",

--- a/data/102/079/271/102079271.geojson
+++ b/data/102/079/271/102079271.geojson
@@ -77,8 +77,13 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "hasc:id":"NZ.WK.HM"
+        "hasc:id":"NZ.WK.HM",
+        "nz-linz:id":"016"
     },
+    "wof:concordances_official":"nz-linz:id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"NZ",
     "wof:geom_alt":[
         "quattroshapes"
@@ -101,7 +106,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1694639722,
+    "wof:lastmodified":1695886108,
     "wof:name":"Hamilton City",
     "wof:parent_id":85687229,
     "wof:placetype":"county",

--- a/data/102/079/273/102079273.geojson
+++ b/data/102/079/273/102079273.geojson
@@ -108,8 +108,13 @@
     "wof:breaches":[],
     "wof:concordances":{
         "hasc:id":"NZ.WK.WP",
+        "nz-linz:id":"017",
         "wd:id":"Q1760796"
     },
+    "wof:concordances_official":"nz-linz:id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"NZ",
     "wof:geom_alt":[
         "quattroshapes"
@@ -132,7 +137,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1694639699,
+    "wof:lastmodified":1695886324,
     "wof:name":"Waipa District",
     "wof:parent_id":85687229,
     "wof:placetype":"county",

--- a/data/102/079/275/102079275.geojson
+++ b/data/102/079/275/102079275.geojson
@@ -91,8 +91,13 @@
     "wof:concordances":{
         "gp:id":55875903,
         "hasc:id":"NZ.WK.OH",
+        "nz-linz:id":"018",
         "wd:id":"Q24490507"
     },
+    "wof:concordances_official":"nz-linz:id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"NZ",
     "wof:geom_alt":[
         "quattroshapes"
@@ -115,7 +120,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1694639699,
+    "wof:lastmodified":1695886325,
     "wof:name":"Otorohanga District",
     "wof:parent_id":85687229,
     "wof:placetype":"county",

--- a/data/102/079/277/102079277.geojson
+++ b/data/102/079/277/102079277.geojson
@@ -103,8 +103,13 @@
     "wof:concordances":{
         "digitalenvoy:metro_code":554058,
         "hasc:id":"NZ.WK.SW",
+        "nz-linz:id":"019",
         "wd:id":"Q1760808"
     },
+    "wof:concordances_official":"nz-linz:id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"NZ",
     "wof:geom_alt":[
         "quattroshapes"
@@ -127,7 +132,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1694639707,
+    "wof:lastmodified":1695886349,
     "wof:name":"South Waikato District",
     "wof:parent_id":85687229,
     "wof:placetype":"county",

--- a/data/102/079/279/102079279.geojson
+++ b/data/102/079/279/102079279.geojson
@@ -116,8 +116,13 @@
         "digitalenvoy:metro_code":554046,
         "gp:id":55875845,
         "hasc:id":"NZ.WK.WO",
+        "nz-linz:id":"020",
         "wd:id":"Q1210773"
     },
+    "wof:concordances_official":"nz-linz:id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"NZ",
     "wof:geom_alt":[
         "quattroshapes"
@@ -140,7 +145,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1694639707,
+    "wof:lastmodified":1695886349,
     "wof:name":"Waitomo District",
     "wof:parent_id":85687229,
     "wof:placetype":"county",

--- a/data/102/079/281/102079281.geojson
+++ b/data/102/079/281/102079281.geojson
@@ -118,8 +118,13 @@
     "wof:concordances":{
         "digitalenvoy:metro_code":554028,
         "hasc:id":"NZ.WK.TP",
+        "nz-linz:id":"021",
         "wd:id":"Q2644349"
     },
+    "wof:concordances_official":"nz-linz:id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"NZ",
     "wof:geom_alt":[
         "quattroshapes"
@@ -142,7 +147,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1694639701,
+    "wof:lastmodified":1695886331,
     "wof:name":"Taupo District",
     "wof:parent_id":85687229,
     "wof:placetype":"county",

--- a/data/102/079/283/102079283.geojson
+++ b/data/102/079/283/102079283.geojson
@@ -84,8 +84,13 @@
     "wof:breaches":[],
     "wof:concordances":{
         "hasc:id":"NZ.BP.WB",
+        "nz-linz:id":"022",
         "wd:id":"Q959152"
     },
+    "wof:concordances_official":"nz-linz:id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"NZ",
     "wof:geom_alt":[
         "quattroshapes"
@@ -108,7 +113,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1694639689,
+    "wof:lastmodified":1695886296,
     "wof:name":"Western Bay of Plenty District",
     "wof:parent_id":85687175,
     "wof:placetype":"county",

--- a/data/102/079/285/102079285.geojson
+++ b/data/102/079/285/102079285.geojson
@@ -62,8 +62,13 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "hasc:id":"NZ.BP.WB"
+        "hasc:id":"NZ.BP.WB",
+        "nz-linz:id":"023"
     },
+    "wof:concordances_official":"nz-linz:id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"NZ",
     "wof:geom_alt":[
         "quattroshapes"
@@ -86,7 +91,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1694639724,
+    "wof:lastmodified":1695886116,
     "wof:name":"Tauranga City",
     "wof:parent_id":85687175,
     "wof:placetype":"county",

--- a/data/102/079/289/102079289.geojson
+++ b/data/102/079/289/102079289.geojson
@@ -292,8 +292,13 @@
     "wof:concordances":{
         "digitalenvoy:metro_code":554012,
         "hasc:id":"NZ.WK.RR",
+        "nz-linz:id":"024",
         "wd:id":"Q208948"
     },
+    "wof:concordances_official":"nz-linz:id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"NZ",
     "wof:geom_alt":[
         "quattroshapes"
@@ -316,7 +321,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1694639700,
+    "wof:lastmodified":1695886326,
     "wof:name":"Rotorua District",
     "wof:parent_id":85687175,
     "wof:placetype":"county",

--- a/data/102/079/291/102079291.geojson
+++ b/data/102/079/291/102079291.geojson
@@ -59,8 +59,13 @@
     "wof:breaches":[],
     "wof:concordances":{
         "digitalenvoy:metro_code":554052,
-        "hasc:id":"NZ.BP.WH"
+        "hasc:id":"NZ.BP.WH",
+        "nz-linz:id":"025"
     },
+    "wof:concordances_official":"nz-linz:id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"NZ",
     "wof:geom_alt":[
         "quattroshapes"
@@ -83,7 +88,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1694639722,
+    "wof:lastmodified":1695886109,
     "wof:name":"Whakatane District",
     "wof:parent_id":85687175,
     "wof:placetype":"county",

--- a/data/102/079/293/102079293.geojson
+++ b/data/102/079/293/102079293.geojson
@@ -105,8 +105,13 @@
     "wof:breaches":[],
     "wof:concordances":{
         "digitalenvoy:metro_code":554060,
-        "hasc:id":"NZ.TK.SF"
+        "hasc:id":"NZ.TK.SF",
+        "nz-linz:id":"034"
     },
+    "wof:concordances_official":"nz-linz:id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"NZ",
     "wof:geom_alt":[
         "quattroshapes"
@@ -129,7 +134,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1694639690,
+    "wof:lastmodified":1695886298,
     "wof:name":"Stratford District",
     "wof:parent_id":85687195,
     "wof:placetype":"county",

--- a/data/102/079/295/102079295.geojson
+++ b/data/102/079/295/102079295.geojson
@@ -112,8 +112,13 @@
     "wof:concordances":{
         "digitalenvoy:metro_code":554021,
         "hasc:id":"NZ.TK.ST",
+        "nz-linz:id":"035",
         "wd:id":"Q1972712"
     },
+    "wof:concordances_official":"nz-linz:id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"NZ",
     "wof:geom_alt":[
         "quattroshapes"
@@ -136,7 +141,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1694639705,
+    "wof:lastmodified":1695886340,
     "wof:name":"South Taranaki District",
     "wof:parent_id":85687195,
     "wof:placetype":"county",

--- a/data/102/079/297/102079297.geojson
+++ b/data/102/079/297/102079297.geojson
@@ -124,8 +124,13 @@
     "wof:concordances":{
         "digitalenvoy:metro_code":554033,
         "hasc:id":"NZ.MW.RP",
+        "nz-linz:id":"036",
         "wd:id":"Q586428"
     },
+    "wof:concordances_official":"nz-linz:id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"NZ",
     "wof:geom_alt":[
         "quattroshapes"
@@ -148,7 +153,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1694639690,
+    "wof:lastmodified":1695886299,
     "wof:name":"Ruapehu District",
     "wof:parent_id":85687251,
     "wof:placetype":"county",

--- a/data/102/079/299/102079299.geojson
+++ b/data/102/079/299/102079299.geojson
@@ -105,8 +105,13 @@
     "wof:breaches":[],
     "wof:concordances":{
         "hasc:id":"NZ.MW.WU",
+        "nz-linz:id":"037",
         "wd:id":"Q10856931"
     },
+    "wof:concordances_official":"nz-linz:id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"NZ",
     "wof:geom_alt":[
         "quattroshapes"
@@ -129,7 +134,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1694639713,
+    "wof:lastmodified":1695886382,
     "wof:name":"Whanganui District",
     "wof:parent_id":85687251,
     "wof:placetype":"county",

--- a/data/102/079/301/102079301.geojson
+++ b/data/102/079/301/102079301.geojson
@@ -121,8 +121,13 @@
     "wof:concordances":{
         "digitalenvoy:metro_code":554031,
         "hasc:id":"NZ.MW.RT",
+        "nz-linz:id":"038",
         "wd:id":"Q591972"
     },
+    "wof:concordances_official":"nz-linz:id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"NZ",
     "wof:geom_alt":[
         "quattroshapes"
@@ -145,7 +150,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1694639699,
+    "wof:lastmodified":1695886323,
     "wof:name":"Rangitikei District",
     "wof:parent_id":85687251,
     "wof:placetype":"county",

--- a/data/102/079/303/102079303.geojson
+++ b/data/102/079/303/102079303.geojson
@@ -108,8 +108,13 @@
     "wof:breaches":[],
     "wof:concordances":{
         "hasc:id":"NZ.MW.MN",
+        "nz-linz:id":"039",
         "wd:id":"Q613305"
     },
+    "wof:concordances_official":"nz-linz:id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"NZ",
     "wof:geom_alt":[
         "quattroshapes"
@@ -132,7 +137,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1694639706,
+    "wof:lastmodified":1695886346,
     "wof:name":"Manawatu District",
     "wof:parent_id":85687251,
     "wof:placetype":"county",

--- a/data/102/079/307/102079307.geojson
+++ b/data/102/079/307/102079307.geojson
@@ -70,8 +70,13 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "hasc:id":"NZ.MW.PN"
+        "hasc:id":"NZ.MW.PN",
+        "nz-linz:id":"040"
     },
+    "wof:concordances_official":"nz-linz:id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"NZ",
     "wof:geom_alt":[
         "quattroshapes"
@@ -94,7 +99,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1694639723,
+    "wof:lastmodified":1695886114,
     "wof:name":"Palmerston North City",
     "wof:parent_id":85687251,
     "wof:placetype":"county",

--- a/data/102/079/309/102079309.geojson
+++ b/data/102/079/309/102079309.geojson
@@ -118,8 +118,13 @@
     "wof:concordances":{
         "digitalenvoy:metro_code":554014,
         "hasc:id":"NZ.MW.TR",
+        "nz-linz:id":"041",
         "wd:id":"Q1750590"
     },
+    "wof:concordances_official":"nz-linz:id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"NZ",
     "wof:geom_alt":[
         "quattroshapes"
@@ -142,7 +147,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1694639693,
+    "wof:lastmodified":1695886307,
     "wof:name":"Tararua District",
     "wof:parent_id":85687251,
     "wof:placetype":"county",

--- a/data/102/079/311/102079311.geojson
+++ b/data/102/079/311/102079311.geojson
@@ -97,8 +97,13 @@
     "wof:concordances":{
         "digitalenvoy:metro_code":554005,
         "hasc:id":"NZ.TK.NP",
+        "nz-linz:id":"033",
         "wd:id":"Q4846747"
     },
+    "wof:concordances_official":"nz-linz:id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"NZ",
     "wof:geom_alt":[
         "quattroshapes"
@@ -121,7 +126,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1694639691,
+    "wof:lastmodified":1695886300,
     "wof:name":"New Plymouth District",
     "wof:parent_id":85687195,
     "wof:placetype":"county",

--- a/data/102/079/313/102079313.geojson
+++ b/data/102/079/313/102079313.geojson
@@ -106,8 +106,13 @@
     "wof:concordances":{
         "digitalenvoy:metro_code":554050,
         "hasc:id":"NZ.MW.HW",
+        "nz-linz:id":"042",
         "wd:id":"Q1232367"
     },
+    "wof:concordances_official":"nz-linz:id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"NZ",
     "wof:geom_alt":[
         "quattroshapes"
@@ -130,7 +135,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1694639706,
+    "wof:lastmodified":1695886346,
     "wof:name":"Horowhenua District",
     "wof:parent_id":85687251,
     "wof:placetype":"county",

--- a/data/102/079/315/102079315.geojson
+++ b/data/102/079/315/102079315.geojson
@@ -109,8 +109,13 @@
     "wof:concordances":{
         "digitalenvoy:metro_code":554048,
         "hasc:id":"NZ.WG.KC",
+        "nz-linz:id":"043",
         "wd:id":"Q1533839"
     },
+    "wof:concordances_official":"nz-linz:id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"NZ",
     "wof:geom_alt":[
         "quattroshapes"
@@ -133,7 +138,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1694639705,
+    "wof:lastmodified":1695886342,
     "wof:name":"Kapiti Coast District",
     "wof:parent_id":85687233,
     "wof:placetype":"county",

--- a/data/102/079/317/102079317.geojson
+++ b/data/102/079/317/102079317.geojson
@@ -72,8 +72,13 @@
     "wof:concordances":{
         "digitalenvoy:metro_code":554041,
         "gp:id":55875866,
-        "hasc:id":"NZ.WG.PR"
+        "hasc:id":"NZ.WG.PR",
+        "nz-linz:id":"044"
     },
+    "wof:concordances_official":"nz-linz:id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"NZ",
     "wof:geom_alt":[
         "quattroshapes"
@@ -96,7 +101,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1694639724,
+    "wof:lastmodified":1695886116,
     "wof:name":"Porirua City",
     "wof:parent_id":85687233,
     "wof:placetype":"county",

--- a/data/102/079/319/102079319.geojson
+++ b/data/102/079/319/102079319.geojson
@@ -100,8 +100,13 @@
     "wof:concordances":{
         "digitalenvoy:metro_code":554066,
         "hasc:id":"NZ.BP.WH",
+        "nz-linz:id":"026",
         "wd:id":"Q1674085"
     },
+    "wof:concordances_official":"nz-linz:id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"NZ",
     "wof:geom_alt":[
         "quattroshapes"
@@ -124,7 +129,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1694639691,
+    "wof:lastmodified":1695886301,
     "wof:name":"Kawerau District",
     "wof:parent_id":85687175,
     "wof:placetype":"county",

--- a/data/102/079/321/102079321.geojson
+++ b/data/102/079/321/102079321.geojson
@@ -134,8 +134,13 @@
         "digitalenvoy:metro_code":554064,
         "gp:id":55875861,
         "hasc:id":"NZ.BP.OP",
+        "nz-linz:id":"027",
         "wd:id":"Q953871"
     },
+    "wof:concordances_official":"nz-linz:id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"NZ",
     "wof:geom_alt":[
         "quattroshapes"
@@ -158,7 +163,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1694639714,
+    "wof:lastmodified":1695886387,
     "wof:name":"Opotiki District",
     "wof:parent_id":85687175,
     "wof:placetype":"county",

--- a/data/102/079/325/102079325.geojson
+++ b/data/102/079/325/102079325.geojson
@@ -247,8 +247,13 @@
     "wof:concordances":{
         "digitalenvoy:metro_code":554015,
         "hasc:id":"NZ.GI.GB",
+        "nz-linz:id":"028",
         "wd:id":"Q140246"
     },
+    "wof:concordances_official":"nz-linz:id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"NZ",
     "wof:geom_alt":[
         "quattroshapes"
@@ -271,7 +276,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1694639803,
+    "wof:lastmodified":1695886644,
     "wof:name":"Gisborne District",
     "wof:parent_id":85687237,
     "wof:placetype":"county",

--- a/data/102/079/327/102079327.geojson
+++ b/data/102/079/327/102079327.geojson
@@ -121,8 +121,13 @@
     "wof:concordances":{
         "digitalenvoy:metro_code":554059,
         "hasc:id":"NZ.HB.WW",
+        "nz-linz:id":"029",
         "wd:id":"Q599594"
     },
+    "wof:concordances_official":"nz-linz:id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"NZ",
     "wof:geom_alt":[
         "quattroshapes"
@@ -145,7 +150,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1694639691,
+    "wof:lastmodified":1695886301,
     "wof:name":"Wairoa District",
     "wof:parent_id":85687189,
     "wof:placetype":"county",

--- a/data/102/079/329/102079329.geojson
+++ b/data/102/079/329/102079329.geojson
@@ -70,8 +70,13 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "hasc:id":"NZ.HB.HS"
+        "hasc:id":"NZ.HB.HS",
+        "nz-linz:id":"030"
     },
+    "wof:concordances_official":"nz-linz:id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"NZ",
     "wof:geom_alt":[
         "quattroshapes"
@@ -94,7 +99,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1694639722,
+    "wof:lastmodified":1695886109,
     "wof:name":"Hastings District",
     "wof:parent_id":85687189,
     "wof:placetype":"county",

--- a/data/102/079/331/102079331.geojson
+++ b/data/102/079/331/102079331.geojson
@@ -70,8 +70,13 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "hasc:id":"NZ.HB.NR"
+        "hasc:id":"NZ.HB.NR",
+        "nz-linz:id":"031"
     },
+    "wof:concordances_official":"nz-linz:id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"NZ",
     "wof:geom_alt":[
         "quattroshapes"
@@ -94,7 +99,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1694639723,
+    "wof:lastmodified":1695886114,
     "wof:name":"Napier City",
     "wof:parent_id":85687189,
     "wof:placetype":"county",

--- a/data/102/079/333/102079333.geojson
+++ b/data/102/079/333/102079333.geojson
@@ -111,8 +111,13 @@
     "wof:breaches":[],
     "wof:concordances":{
         "hasc:id":"NZ.HB.CH",
+        "nz-linz:id":"032",
         "wd:id":"Q1053673"
     },
+    "wof:concordances_official":"nz-linz:id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"NZ",
     "wof:geom_alt":[
         "quattroshapes"
@@ -135,7 +140,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1694639691,
+    "wof:lastmodified":1695886302,
     "wof:name":"Central Hawke's Bay District",
     "wof:parent_id":85687189,
     "wof:placetype":"county",

--- a/data/102/079/335/102079335.geojson
+++ b/data/102/079/335/102079335.geojson
@@ -71,8 +71,13 @@
     "wof:breaches":[],
     "wof:concordances":{
         "digitalenvoy:metro_code":554025,
-        "hasc:id":"NZ.WG.UH"
+        "hasc:id":"NZ.WG.UH",
+        "nz-linz:id":"045"
     },
+    "wof:concordances_official":"nz-linz:id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"NZ",
     "wof:geom_alt":[
         "quattroshapes"
@@ -95,7 +100,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1694639724,
+    "wof:lastmodified":1695886117,
     "wof:name":"Upper Hutt City",
     "wof:parent_id":85687233,
     "wof:placetype":"county",

--- a/data/102/079/337/102079337.geojson
+++ b/data/102/079/337/102079337.geojson
@@ -75,8 +75,13 @@
     "wof:concordances":{
         "digitalenvoy:metro_code":554009,
         "gp:id":55875918,
-        "hasc:id":"NZ.WG.LH"
+        "hasc:id":"NZ.WG.LH",
+        "nz-linz:id":"046"
     },
+    "wof:concordances_official":"nz-linz:id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"NZ",
     "wof:geom_alt":[
         "quattroshapes"
@@ -99,7 +104,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1694639723,
+    "wof:lastmodified":1695886114,
     "wof:name":"Lower Hutt City",
     "wof:parent_id":85687233,
     "wof:placetype":"county",

--- a/data/102/079/339/102079339.geojson
+++ b/data/102/079/339/102079339.geojson
@@ -91,8 +91,13 @@
     "wof:concordances":{
         "digitalenvoy:metro_code":554004,
         "hasc:id":"NZ.WG.WE",
+        "nz-linz:id":"047",
         "wd:id":"Q601800"
     },
+    "wof:concordances_official":"nz-linz:id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"NZ",
     "wof:geom_alt":[
         "quattroshapes"
@@ -115,7 +120,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1694639725,
+    "wof:lastmodified":1695886119,
     "wof:name":"Wellington City",
     "wof:parent_id":85687233,
     "wof:placetype":"county",

--- a/data/102/079/343/102079343.geojson
+++ b/data/102/079/343/102079343.geojson
@@ -71,8 +71,13 @@
     "wof:breaches":[],
     "wof:concordances":{
         "digitalenvoy:metro_code":554047,
-        "hasc:id":"NZ.WG.MT"
+        "hasc:id":"NZ.WG.MT",
+        "nz-linz:id":"048"
     },
+    "wof:concordances_official":"nz-linz:id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"NZ",
     "wof:geom_alt":[
         "quattroshapes"
@@ -95,7 +100,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1694639724,
+    "wof:lastmodified":1695886115,
     "wof:name":"Masterton District",
     "wof:parent_id":85687233,
     "wof:placetype":"county",

--- a/data/102/079/345/102079345.geojson
+++ b/data/102/079/345/102079345.geojson
@@ -301,8 +301,13 @@
     "wof:concordances":{
         "digitalenvoy:metro_code":554061,
         "hasc:id":"NZ.WG.CR",
+        "nz-linz:id":"049",
         "wd:id":"Q1045948"
     },
+    "wof:concordances_official":"nz-linz:id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"NZ",
     "wof:geom_alt":[
         "quattroshapes"
@@ -325,7 +330,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1694639714,
+    "wof:lastmodified":1695886385,
     "wof:name":"Carterton District",
     "wof:parent_id":85687233,
     "wof:placetype":"county",

--- a/data/102/079/347/102079347.geojson
+++ b/data/102/079/347/102079347.geojson
@@ -100,8 +100,13 @@
     "wof:concordances":{
         "digitalenvoy:metro_code":554054,
         "hasc:id":"NZ.WG.SP",
+        "nz-linz:id":"050",
         "wd:id":"Q1760817"
     },
+    "wof:concordances_official":"nz-linz:id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"NZ",
     "wof:geom_alt":[
         "quattroshapes"
@@ -124,7 +129,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1694639706,
+    "wof:lastmodified":1695886345,
     "wof:name":"South Wairarapa District",
     "wof:parent_id":85687233,
     "wof:placetype":"county",

--- a/data/102/079/349/102079349.geojson
+++ b/data/102/079/349/102079349.geojson
@@ -226,8 +226,13 @@
     "wof:concordances":{
         "digitalenvoy:metro_code":554035,
         "hasc:id":"NZ.TS.TM",
+        "nz-linz:id":"051",
         "wd:id":"Q666142"
     },
+    "wof:concordances_official":"nz-linz:id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"NZ",
     "wof:geom_alt":[
         "quattroshapes"
@@ -250,7 +255,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1694639802,
+    "wof:lastmodified":1695886642,
     "wof:name":"Tasman District",
     "wof:parent_id":85687219,
     "wof:placetype":"county",

--- a/data/102/079/351/102079351.geojson
+++ b/data/102/079/351/102079351.geojson
@@ -75,8 +75,13 @@
     "wof:breaches":[],
     "wof:concordances":{
         "digitalenvoy:metro_code":554020,
-        "hasc:id":"NZ.NE.NL"
+        "hasc:id":"NZ.NE.NL",
+        "nz-linz:id":"052"
     },
+    "wof:concordances_official":"nz-linz:id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"NZ",
     "wof:geom_alt":[
         "quattroshapes"
@@ -99,7 +104,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1694639724,
+    "wof:lastmodified":1695886115,
     "wof:name":"Nelson City",
     "wof:parent_id":85687157,
     "wof:placetype":"county",

--- a/data/102/079/353/102079353.geojson
+++ b/data/102/079/353/102079353.geojson
@@ -153,8 +153,13 @@
     "wof:concordances":{
         "digitalenvoy:metro_code":554016,
         "gp:id":55875875,
-        "hasc:id":"NZ.MA.MB"
+        "hasc:id":"NZ.MA.MB",
+        "nz-linz:id":"053"
     },
+    "wof:concordances_official":"nz-linz:id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"NZ",
     "wof:geom_alt":[
         "quattroshapes"
@@ -177,7 +182,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1694639798,
+    "wof:lastmodified":1695886635,
     "wof:name":"Marlborough District",
     "wof:parent_id":85687185,
     "wof:placetype":"county",

--- a/data/102/079/355/102079355.geojson
+++ b/data/102/079/355/102079355.geojson
@@ -71,8 +71,13 @@
     "wof:breaches":[],
     "wof:concordances":{
         "digitalenvoy:metro_code":554038,
-        "hasc:id":"NZ.CA.KK"
+        "hasc:id":"NZ.CA.KK",
+        "nz-linz:id":"054"
     },
+    "wof:concordances_official":"nz-linz:id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"NZ",
     "wof:geom_alt":[
         "quattroshapes"
@@ -95,7 +100,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1694639725,
+    "wof:lastmodified":1695886117,
     "wof:name":"Kaikoura District",
     "wof:parent_id":85687179,
     "wof:placetype":"county",

--- a/data/102/079/357/102079357.geojson
+++ b/data/102/079/357/102079357.geojson
@@ -107,8 +107,13 @@
         "digitalenvoy:metro_code":554055,
         "gp:id":55875916,
         "hasc:id":"NZ.WC.BU",
+        "nz-linz:id":"055",
         "wd:id":"Q1004325"
     },
+    "wof:concordances_official":"nz-linz:id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"NZ",
     "wof:geom_alt":[
         "quattroshapes"
@@ -131,7 +136,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1694639692,
+    "wof:lastmodified":1695886303,
     "wof:name":"Buller District",
     "wof:parent_id":85687165,
     "wof:placetype":"county",

--- a/data/102/079/361/102079361.geojson
+++ b/data/102/079/361/102079361.geojson
@@ -106,8 +106,13 @@
     "wof:concordances":{
         "gp:id":55875922,
         "hasc:id":"NZ.WC.GR",
+        "nz-linz:id":"056",
         "wd:id":"Q642203"
     },
+    "wof:concordances_official":"nz-linz:id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"NZ",
     "wof:geom_alt":[
         "quattroshapes"
@@ -130,7 +135,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1694639692,
+    "wof:lastmodified":1695886305,
     "wof:name":"Grey District",
     "wof:parent_id":85687165,
     "wof:placetype":"county",

--- a/data/102/079/363/102079363.geojson
+++ b/data/102/079/363/102079363.geojson
@@ -109,8 +109,13 @@
     "wof:concordances":{
         "digitalenvoy:metro_code":554049,
         "hasc:id":"NZ.WC.WL",
+        "nz-linz:id":"057",
         "wd:id":"Q2119644"
     },
+    "wof:concordances_official":"nz-linz:id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"NZ",
     "wof:geom_alt":[
         "quattroshapes"
@@ -133,7 +138,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1694639721,
+    "wof:lastmodified":1695886105,
     "wof:name":"Westland District",
     "wof:parent_id":85687165,
     "wof:placetype":"county",

--- a/data/102/079/365/102079365.geojson
+++ b/data/102/079/365/102079365.geojson
@@ -116,8 +116,13 @@
         "digitalenvoy:metro_code":554038,
         "gp:id":55875849,
         "hasc:id":"NZ.CA.HN",
+        "nz-linz:id":"058",
         "wd:id":"Q1638765"
     },
+    "wof:concordances_official":"nz-linz:id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"NZ",
     "wof:geom_alt":[
         "quattroshapes"
@@ -140,7 +145,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1694639698,
+    "wof:lastmodified":1695886321,
     "wof:name":"Hurunui District",
     "wof:parent_id":85687179,
     "wof:placetype":"county",

--- a/data/102/079/367/102079367.geojson
+++ b/data/102/079/367/102079367.geojson
@@ -106,8 +106,13 @@
     "wof:concordances":{
         "digitalenvoy:metro_code":554045,
         "hasc:id":"NZ.CA.WR",
+        "nz-linz:id":"059",
         "wd:id":"Q1542322"
     },
+    "wof:concordances_official":"nz-linz:id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"NZ",
     "wof:geom_alt":[
         "quattroshapes"
@@ -130,7 +135,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1694639707,
+    "wof:lastmodified":1695886348,
     "wof:name":"Waimakariri District",
     "wof:parent_id":85687179,
     "wof:placetype":"county",

--- a/data/102/079/369/102079369.geojson
+++ b/data/102/079/369/102079369.geojson
@@ -118,8 +118,13 @@
     "wof:concordances":{
         "digitalenvoy:metro_code":554027,
         "hasc:id":"NZ.CA.SY",
+        "nz-linz:id":"062",
         "wd:id":"Q1210763"
     },
+    "wof:concordances_official":"nz-linz:id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"NZ",
     "wof:geom_alt":[
         "quattroshapes"
@@ -142,7 +147,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1694639707,
+    "wof:lastmodified":1695886347,
     "wof:name":"Selwyn District",
     "wof:parent_id":85687179,
     "wof:placetype":"county",

--- a/data/102/079/371/102079371.geojson
+++ b/data/102/079/371/102079371.geojson
@@ -77,8 +77,13 @@
     "wof:breaches":[],
     "wof:concordances":{
         "digitalenvoy:metro_code":554037,
-        "hasc:id":"NZ.CA.AB"
+        "hasc:id":"NZ.CA.AB",
+        "nz-linz:id":"063"
     },
+    "wof:concordances_official":"nz-linz:id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"NZ",
     "wof:geom_alt":[
         "quattroshapes"
@@ -101,7 +106,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1694639720,
+    "wof:lastmodified":1695886102,
     "wof:name":"Ashburton District",
     "wof:parent_id":85687179,
     "wof:placetype":"county",

--- a/data/102/079/373/102079373.geojson
+++ b/data/102/079/373/102079373.geojson
@@ -91,8 +91,13 @@
     "wof:concordances":{
         "digitalenvoy:metro_code":554018,
         "hasc:id":"NZ.CA.TU",
+        "nz-linz:id":"064",
         "wd:id":"Q14395599"
     },
+    "wof:concordances_official":"nz-linz:id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"NZ",
     "wof:geom_alt":[
         "quattroshapes"
@@ -115,7 +120,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1694639714,
+    "wof:lastmodified":1695886386,
     "wof:name":"Timaru District",
     "wof:parent_id":85687179,
     "wof:placetype":"county",

--- a/data/102/079/375/102079375.geojson
+++ b/data/102/079/375/102079375.geojson
@@ -115,8 +115,13 @@
     "wof:concordances":{
         "digitalenvoy:metro_code":554065,
         "hasc:id":"NZ.CA.MZ",
+        "nz-linz:id":"065",
         "wd:id":"Q1760822"
     },
+    "wof:concordances_official":"nz-linz:id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"NZ",
     "wof:geom_alt":[
         "quattroshapes"
@@ -139,7 +144,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1694639715,
+    "wof:lastmodified":1695886389,
     "wof:name":"Mackenzie District",
     "wof:parent_id":85687179,
     "wof:placetype":"county",

--- a/data/102/079/379/102079379.geojson
+++ b/data/102/079/379/102079379.geojson
@@ -81,8 +81,13 @@
     "wof:breaches":[],
     "wof:concordances":{
         "digitalenvoy:metro_code":554056,
-        "hasc:id":"NZ.CA.WM"
+        "hasc:id":"NZ.CA.WM",
+        "nz-linz:id":"066"
     },
+    "wof:concordances_official":"nz-linz:id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"NZ",
     "wof:geom_alt":[
         "quattroshapes"
@@ -105,7 +110,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1694639725,
+    "wof:lastmodified":1695886118,
     "wof:name":"Waimate District",
     "wof:parent_id":85687179,
     "wof:placetype":"county",

--- a/data/102/079/381/102079381.geojson
+++ b/data/102/079/381/102079381.geojson
@@ -119,8 +119,13 @@
     "wof:concordances":{
         "digitalenvoy:metro_code":554029,
         "hasc:id":"NZ.OT.WI",
+        "nz-linz:id":"068",
         "wd:id":"Q1760804"
     },
+    "wof:concordances_official":"nz-linz:id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:controlled":[
         "wof:parent_id",
         "wof:hierarchy"
@@ -153,7 +158,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1694639715,
+    "wof:lastmodified":1695886390,
     "wof:name":"Waitaki District",
     "wof:parent_id":-4,
     "wof:placetype":"county",

--- a/data/102/079/383/102079383.geojson
+++ b/data/102/079/383/102079383.geojson
@@ -112,8 +112,13 @@
     "wof:concordances":{
         "digitalenvoy:metro_code":554034,
         "hasc:id":"NZ.OT.CO",
+        "nz-linz:id":"069",
         "wd:id":"Q1053677"
     },
+    "wof:concordances_official":"nz-linz:id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"NZ",
     "wof:geom_alt":[
         "quattroshapes"
@@ -136,7 +141,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1694639705,
+    "wof:lastmodified":1695886341,
     "wof:name":"Central Otago District",
     "wof:parent_id":85687201,
     "wof:placetype":"county",

--- a/data/102/079/385/102079385.geojson
+++ b/data/102/079/385/102079385.geojson
@@ -116,8 +116,13 @@
         "digitalenvoy:metro_code":554053,
         "gp:id":55875858,
         "hasc:id":"NZ.OT.QL",
+        "nz-linz:id":"070",
         "wd:id":"Q613684"
     },
+    "wof:concordances_official":"nz-linz:id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"NZ",
     "wof:geom_alt":[
         "quattroshapes"
@@ -140,7 +145,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1694639706,
+    "wof:lastmodified":1695886343,
     "wof:name":"Queenstown-Lakes District",
     "wof:parent_id":85687201,
     "wof:placetype":"county",

--- a/data/102/079/387/102079387.geojson
+++ b/data/102/079/387/102079387.geojson
@@ -82,8 +82,13 @@
     "wof:concordances":{
         "digitalenvoy:metro_code":554003,
         "hasc:id":"NZ.OT.DU",
+        "nz-linz:id":"071",
         "wd:id":"Q3041298"
     },
+    "wof:concordances_official":"nz-linz:id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"NZ",
     "wof:geom_alt":[
         "quattroshapes"
@@ -106,7 +111,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1694639693,
+    "wof:lastmodified":1695886306,
     "wof:name":"Dunedin City",
     "wof:parent_id":85687201,
     "wof:placetype":"county",

--- a/data/102/079/389/102079389.geojson
+++ b/data/102/079/389/102079389.geojson
@@ -118,8 +118,13 @@
     "wof:concordances":{
         "digitalenvoy:metro_code":554023,
         "hasc:id":"NZ.OT.CL",
+        "nz-linz:id":"072",
         "wd:id":"Q1103566"
     },
+    "wof:concordances_official":"nz-linz:id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"NZ",
     "wof:geom_alt":[
         "quattroshapes"
@@ -142,7 +147,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1694639713,
+    "wof:lastmodified":1695886383,
     "wof:name":"Clutha District",
     "wof:parent_id":85687201,
     "wof:placetype":"county",

--- a/data/102/079/391/102079391.geojson
+++ b/data/102/079/391/102079391.geojson
@@ -117,8 +117,13 @@
     "wof:breaches":[],
     "wof:concordances":{
         "hasc:id":"NZ.SO.SL",
+        "nz-linz:id":"073",
         "wd:id":"Q1972706"
     },
+    "wof:concordances_official":"nz-linz:id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"NZ",
     "wof:geom_alt":[
         "quattroshapes"
@@ -141,7 +146,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1694639694,
+    "wof:lastmodified":1695886309,
     "wof:name":"Southland District",
     "wof:parent_id":85687211,
     "wof:placetype":"county",

--- a/data/102/079/393/102079393.geojson
+++ b/data/102/079/393/102079393.geojson
@@ -71,8 +71,13 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "hasc:id":"NZ.SO.GO"
+        "hasc:id":"NZ.SO.GO",
+        "nz-linz:id":"074"
     },
+    "wof:concordances_official":"nz-linz:id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"NZ",
     "wof:geom_alt":[
         "quattroshapes"
@@ -95,7 +100,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1694639723,
+    "wof:lastmodified":1695886110,
     "wof:name":"Gore District",
     "wof:parent_id":85687211,
     "wof:placetype":"county",

--- a/data/102/079/397/102079397.geojson
+++ b/data/102/079/397/102079397.geojson
@@ -70,8 +70,13 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "hasc:id":"NZ.SO.IC"
+        "hasc:id":"NZ.SO.IC",
+        "nz-linz:id":"075"
     },
+    "wof:concordances_official":"nz-linz:id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"NZ",
     "wof:geom_alt":[
         "quattroshapes"
@@ -94,7 +99,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1694639723,
+    "wof:lastmodified":1695886111,
     "wof:name":"Invercargill City",
     "wof:parent_id":85687211,
     "wof:placetype":"county",

--- a/data/102/079/401/102079401.geojson
+++ b/data/102/079/401/102079401.geojson
@@ -72,8 +72,13 @@
     "wof:breaches":[],
     "wof:concordances":{
         "digitalenvoy:metro_code":554002,
-        "hasc:id":"NZ.CA.CC"
+        "hasc:id":"NZ.CA.CC",
+        "nz-linz:id":"060"
     },
+    "wof:concordances_official":"nz-linz:id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"NZ",
     "wof:geom_alt":[
         "quattroshapes"
@@ -96,7 +101,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1694639720,
+    "wof:lastmodified":1695886103,
     "wof:name":"Christchurch City",
     "wof:parent_id":85687179,
     "wof:placetype":"county",

--- a/data/110/856/456/7/1108564567.geojson
+++ b/data/110/856/456/7/1108564567.geojson
@@ -65,6 +65,7 @@
     "wof:concordances":{
         "hasc:id":"NZ.CI.CT"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NZ",
     "wof:created":1474058937,
     "wof:geomhash":"131493b01a4570c50ea120648a29ccc0",
@@ -85,7 +86,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1694498065,
+    "wof:lastmodified":1695886112,
     "wof:name":"Chatham Islands Territory",
     "wof:parent_id":85687215,
     "wof:placetype":"county",

--- a/data/110/856/457/3/1108564573.geojson
+++ b/data/110/856/457/3/1108564573.geojson
@@ -58,8 +58,13 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "hasc:id":"NZ.BP.WB"
+        "hasc:id":"NZ.BP.WB",
+        "nz-linz:id":"999"
     },
+    "wof:concordances_official":"nz-linz:id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"NZ",
     "wof:created":1474059006,
     "wof:geomhash":"7037b0c1a41dec119ea0e867c930f317",
@@ -80,7 +85,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1694498070,
+    "wof:lastmodified":1695886250,
     "wof:name":"Area Outside Territorial Authority",
     "wof:parent_id":85687175,
     "wof:placetype":"county",

--- a/data/172/923/842/5/1729238425.geojson
+++ b/data/172/923/842/5/1729238425.geojson
@@ -5,11 +5,17 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.008672,
-    "geom:area_square_m":84549074.288974,
+    "geom:area_square_m":84549074.289136,
     "geom:bbox":"175.724151,-38.021227,175.846604,-37.890305",
     "geom:latitude":-37.957946,
     "geom:longitude":175.779809,
     "iso:country":"NZ",
+    "label:eng_x_preferred_placetype":[
+        "territorial authority district"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "autorit\u00e9 territoriale"
+    ],
     "lbl:latitude":-37.959838,
     "lbl:longitude":175.775643,
     "lbl:max_zoom":13.0,
@@ -37,7 +43,7 @@
     ],
     "wof:country":"NZ",
     "wof:created":1600724597,
-    "wof:geomhash":"a6acf4676876562c4cc6833f30ea8510",
+    "wof:geomhash":"f3ebca22b7350c98419cabd6166fea52",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -56,7 +62,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1617131311,
+    "wof:lastmodified":1695878941,
     "wof:name":"Tirau",
     "wof:parent_id":102079277,
     "wof:placetype":"localadmin",

--- a/data/172/923/842/9/1729238429.geojson
+++ b/data/172/923/842/9/1729238429.geojson
@@ -5,11 +5,17 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.009574,
-    "geom:area_square_m":95641933.093934,
+    "geom:area_square_m":95641933.093821,
     "geom:bbox":"174.482169,-36.1756,174.636913,-36.04291",
     "geom:latitude":-36.112841,
     "geom:longitude":174.562429,
     "iso:country":"NZ",
+    "label:eng_x_preferred_placetype":[
+        "territorial authority district"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "autorit\u00e9 territoriale"
+    ],
     "lbl:latitude":-36.099673,
     "lbl:longitude":174.550729,
     "lbl:max_zoom":13.0,
@@ -37,7 +43,7 @@
     ],
     "wof:country":"NZ",
     "wof:created":1600724598,
-    "wof:geomhash":"f6e9f8fcf10231420f2fb04006ba7021",
+    "wof:geomhash":"10b7eccdf9b0ae8b24344ca979a8e7dc",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -56,7 +62,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1603139572,
+    "wof:lastmodified":1695878918,
     "wof:name":"Mangawhai",
     "wof:parent_id":102079259,
     "wof:placetype":"localadmin",

--- a/data/172/923/843/1/1729238431.geojson
+++ b/data/172/923/843/1/1729238431.geojson
@@ -5,11 +5,17 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.010201,
-    "geom:area_square_m":91321077.814316,
+    "geom:area_square_m":91321077.81452,
     "geom:bbox":"172.19363,-43.661493,172.377916,-43.561124",
     "geom:latitude":-43.616631,
     "geom:longitude":172.284907,
     "iso:country":"NZ",
+    "label:eng_x_preferred_placetype":[
+        "territorial authority district"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "autorit\u00e9 territoriale"
+    ],
     "lbl:latitude":-43.619628,
     "lbl:longitude":172.286272,
     "lbl:max_zoom":13.0,
@@ -37,7 +43,7 @@
     ],
     "wof:country":"NZ",
     "wof:created":1600724599,
-    "wof:geomhash":"2f9eecf3530911c5020b6ace1f8dd182",
+    "wof:geomhash":"9ce24908f99606accab2991b95e8cbe1",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -56,7 +62,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1603139576,
+    "wof:lastmodified":1695878918,
     "wof:name":"Burnham",
     "wof:parent_id":102079369,
     "wof:placetype":"localadmin",

--- a/data/172/923/843/3/1729238433.geojson
+++ b/data/172/923/843/3/1729238433.geojson
@@ -5,11 +5,17 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.000543,
-    "geom:area_square_m":5023445.140356,
+    "geom:area_square_m":5023445.140305,
     "geom:bbox":"171.866856,-41.61937,171.916953,-41.567988",
     "geom:latitude":-41.592915,
     "geom:longitude":171.892815,
     "iso:country":"NZ",
+    "label:eng_x_preferred_placetype":[
+        "territorial authority district"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "autorit\u00e9 territoriale"
+    ],
     "lbl:latitude":-41.580959,
     "lbl:longitude":171.902857,
     "lbl:max_zoom":13.0,
@@ -37,7 +43,7 @@
     ],
     "wof:country":"NZ",
     "wof:created":1600724599,
-    "wof:geomhash":"bbee6a576f63643754cda88b0aec441b",
+    "wof:geomhash":"5c662c972606fc6144ba47a0b50b052f",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -56,7 +62,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1617130306,
+    "wof:lastmodified":1695878938,
     "wof:name":"Hector",
     "wof:parent_id":102079357,
     "wof:placetype":"localadmin",

--- a/data/172/923/843/5/1729238435.geojson
+++ b/data/172/923/843/5/1729238435.geojson
@@ -5,11 +5,17 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.006966,
-    "geom:area_square_m":68120108.661077,
+    "geom:area_square_m":68120108.661435,
     "geom:bbox":"176.237248,-37.777807,176.415649,-37.67651",
     "geom:latitude":-37.732498,
     "geom:longitude":176.308745,
     "iso:country":"NZ",
+    "label:eng_x_preferred_placetype":[
+        "territorial authority district"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "autorit\u00e9 territoriale"
+    ],
     "lbl:latitude":-37.727939,
     "lbl:longitude":176.308748,
     "lbl:max_zoom":13.0,
@@ -37,7 +43,7 @@
     ],
     "wof:country":"NZ",
     "wof:created":1600724600,
-    "wof:geomhash":"44ca87fe8f8166e06b48ea33c084896c",
+    "wof:geomhash":"cf26feb9480c2bad1b485ebc7b2492d1",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -56,7 +62,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1617130313,
+    "wof:lastmodified":1695878938,
     "wof:name":"Papamoa",
     "wof:parent_id":102079283,
     "wof:placetype":"localadmin",

--- a/data/172/923/843/7/1729238437.geojson
+++ b/data/172/923/843/7/1729238437.geojson
@@ -5,11 +5,17 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.016971,
-    "geom:area_square_m":160107405.645689,
+    "geom:area_square_m":160107405.645666,
     "geom:bbox":"175.20596,-40.363132,175.390243,-40.200979",
     "geom:latitude":-40.273693,
     "geom:longitude":175.284639,
     "iso:country":"NZ",
+    "label:eng_x_preferred_placetype":[
+        "territorial authority district"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "autorit\u00e9 territoriale"
+    ],
     "lbl:latitude":-40.272359,
     "lbl:longitude":175.284612,
     "lbl:max_zoom":13.0,
@@ -37,7 +43,7 @@
     ],
     "wof:country":"NZ",
     "wof:created":1600724601,
-    "wof:geomhash":"d2e992c5f42c74bd015a68e0bb06650c",
+    "wof:geomhash":"ccd6f8db24040b6e06ff617c216d3849",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -56,7 +62,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1603139590,
+    "wof:lastmodified":1695878918,
     "wof:name":"Tangimoana",
     "wof:parent_id":102079301,
     "wof:placetype":"localadmin",

--- a/data/172/923/843/9/1729238439.geojson
+++ b/data/172/923/843/9/1729238439.geojson
@@ -5,11 +5,17 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.025687,
-    "geom:area_square_m":225642080.288647,
+    "geom:area_square_m":225642080.288672,
     "geom:bbox":"170.29161,-44.84528,170.543599,-44.612051",
     "geom:latitude":-44.73205,
     "geom:longitude":170.419849,
     "iso:country":"NZ",
+    "label:eng_x_preferred_placetype":[
+        "territorial authority district"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "autorit\u00e9 territoriale"
+    ],
     "lbl:latitude":-44.74133,
     "lbl:longitude":170.419839,
     "lbl:max_zoom":13.0,
@@ -37,7 +43,7 @@
     ],
     "wof:country":"NZ",
     "wof:created":1600724602,
-    "wof:geomhash":"6e68c2d769b7cd10e8539d4a8442417c",
+    "wof:geomhash":"e9601748a131b1c111b8cef7ec715a80",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -56,7 +62,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1603139595,
+    "wof:lastmodified":1695878918,
     "wof:name":"Kurow",
     "wof:parent_id":102079381,
     "wof:placetype":"localadmin",

--- a/data/172/923/844/1/1729238441.geojson
+++ b/data/172/923/844/1/1729238441.geojson
@@ -5,11 +5,17 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.009343,
-    "geom:area_square_m":92510852.425578,
+    "geom:area_square_m":92510852.425467,
     "geom:bbox":"174.9815,-36.848275,175.202979,-36.737837",
     "geom:latitude":-36.795983,
     "geom:longitude":175.103182,
     "iso:country":"NZ",
+    "label:eng_x_preferred_placetype":[
+        "territorial authority district"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "autorit\u00e9 territoriale"
+    ],
     "lbl:latitude":-36.795252,
     "lbl:longitude":175.129073,
     "lbl:max_zoom":13.0,
@@ -37,7 +43,7 @@
     ],
     "wof:country":"NZ",
     "wof:created":1600724603,
-    "wof:geomhash":"a5f0937f33c7a8787d276edb526ef504",
+    "wof:geomhash":"916112e272d121452f0e94fd73becd11",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -56,7 +62,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1617130188,
+    "wof:lastmodified":1695878935,
     "wof:name":"Waiheke Island",
     "wof:parent_id":102079403,
     "wof:placetype":"localadmin",

--- a/data/172/923/844/3/1729238443.geojson
+++ b/data/172/923/844/3/1729238443.geojson
@@ -5,11 +5,17 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.004735,
-    "geom:area_square_m":46894389.275893,
+    "geom:area_square_m":46894389.275882,
     "geom:bbox":"174.49386,-36.833878,174.606312,-36.752945",
     "geom:latitude":-36.786132,
     "geom:longitude":174.541948,
     "iso:country":"NZ",
+    "label:eng_x_preferred_placetype":[
+        "territorial authority district"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "autorit\u00e9 territoriale"
+    ],
     "lbl:latitude":-36.780741,
     "lbl:longitude":174.541106,
     "lbl:max_zoom":13.0,
@@ -37,7 +43,7 @@
     ],
     "wof:country":"NZ",
     "wof:created":1600724604,
-    "wof:geomhash":"92c32c47e325ced9df7a2e878eef59dc",
+    "wof:geomhash":"1092d154bec7de279be90eafc7ef6ebe",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -56,7 +62,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1617130190,
+    "wof:lastmodified":1695878937,
     "wof:name":"Kumeu",
     "wof:parent_id":102079403,
     "wof:placetype":"localadmin",

--- a/data/172/923/844/7/1729238447.geojson
+++ b/data/172/923/844/7/1729238447.geojson
@@ -5,11 +5,17 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.00781,
-    "geom:area_square_m":72506319.277066,
+    "geom:area_square_m":72506319.277113,
     "geom:bbox":"173.083258,-41.409258,173.231914,-41.282632",
     "geom:latitude":-41.341361,
     "geom:longitude":173.151341,
     "iso:country":"NZ",
+    "label:eng_x_preferred_placetype":[
+        "territorial authority district"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "autorit\u00e9 territoriale"
+    ],
     "lbl:latitude":-41.34378,
     "lbl:longitude":173.150241,
     "lbl:max_zoom":13.0,
@@ -82,7 +88,7 @@
     ],
     "wof:country":"NZ",
     "wof:created":1600724605,
-    "wof:geomhash":"cb9e0d384d6314d8b5c665b219ee2954",
+    "wof:geomhash":"a07cc90d9ac38c0ea68ed0f668bf34ba",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -101,7 +107,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1636495079,
+    "wof:lastmodified":1695878944,
     "wof:name":"Richmond",
     "wof:parent_id":102079349,
     "wof:placetype":"localadmin",

--- a/data/172/923/844/7/1729238447.geojson
+++ b/data/172/923/844/7/1729238447.geojson
@@ -11,10 +11,10 @@
     "geom:longitude":173.151341,
     "iso:country":"NZ",
     "label:eng_x_preferred_placetype":[
-        "territorial authority district"
+        "unitary authority"
     ],
     "label:fra_x_preferred_placetype":[
-        "autorit\u00e9 territoriale"
+        "autorit\u00e9 unitaire"
     ],
     "lbl:latitude":-41.34378,
     "lbl:longitude":173.150241,
@@ -107,7 +107,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1695878944,
+    "wof:lastmodified":1696022878,
     "wof:name":"Richmond",
     "wof:parent_id":102079349,
     "wof:placetype":"localadmin",

--- a/data/172/923/844/9/1729238449.geojson
+++ b/data/172/923/844/9/1729238449.geojson
@@ -5,11 +5,17 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.003157,
-    "geom:area_square_m":27488476.682541,
+    "geom:area_square_m":27488476.682586,
     "geom:bbox":"169.338669,-45.267682,169.420338,-45.19897",
     "geom:latitude":-45.23058,
     "geom:longitude":169.379788,
     "iso:country":"NZ",
+    "label:eng_x_preferred_placetype":[
+        "territorial authority district"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "autorit\u00e9 territoriale"
+    ],
     "lbl:latitude":-45.232793,
     "lbl:longitude":169.385941,
     "lbl:max_zoom":13.0,
@@ -37,7 +43,7 @@
     ],
     "wof:country":"NZ",
     "wof:created":1600724607,
-    "wof:geomhash":"b911ebff0308454ada7aeb934f25245b",
+    "wof:geomhash":"594b2a2e0fcf43e0cb11b1e7258d3542",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -56,7 +62,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1603139665,
+    "wof:lastmodified":1695878919,
     "wof:name":"Alexandra",
     "wof:parent_id":102079383,
     "wof:placetype":"localadmin",

--- a/data/172/923/845/1/1729238451.geojson
+++ b/data/172/923/845/1/1729238451.geojson
@@ -5,11 +5,17 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.012806,
-    "geom:area_square_m":114066661.693441,
+    "geom:area_square_m":114066661.693316,
     "geom:bbox":"171.652233,-43.987103,171.902269,-43.845443",
     "geom:latitude":-43.915941,
     "geom:longitude":171.766778,
     "iso:country":"NZ",
+    "label:eng_x_preferred_placetype":[
+        "territorial authority district"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "autorit\u00e9 territoriale"
+    ],
     "lbl:latitude":-43.902355,
     "lbl:longitude":171.743997,
     "lbl:max_zoom":13.0,
@@ -76,7 +82,7 @@
     ],
     "wof:country":"NZ",
     "wof:created":1600724607,
-    "wof:geomhash":"d5c4d12d1a56358d952cf29a29a8abe5",
+    "wof:geomhash":"62e5d1accc286e862d0b9bfb98f65250",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -95,7 +101,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1636495078,
+    "wof:lastmodified":1695878943,
     "wof:name":"Ashburton",
     "wof:parent_id":102079371,
     "wof:placetype":"localadmin",

--- a/data/172/923/845/5/1729238455.geojson
+++ b/data/172/923/845/5/1729238455.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.016145,
-    "geom:area_square_m":149364806.257959,
+    "geom:area_square_m":149364806.258103,
     "geom:bbox":"173.85761,-41.661859,174.031981,-41.462039",
     "geom:latitude":-41.565504,
     "geom:longitude":173.946646,
@@ -43,7 +43,7 @@
     ],
     "wof:country":"NZ",
     "wof:created":1600724615,
-    "wof:geomhash":"6f283f1519d7d3e08f1ae5e33936afe5",
+    "wof:geomhash":"3a2b878ec8e4f2a24d458dda47feb359",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -62,7 +62,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1636495078,
+    "wof:lastmodified":1695878943,
     "wof:name":"Blenheim",
     "wof:parent_id":102079353,
     "wof:placetype":"localadmin",

--- a/data/172/923/845/5/1729238455.geojson
+++ b/data/172/923/845/5/1729238455.geojson
@@ -10,6 +10,12 @@
     "geom:latitude":-41.565504,
     "geom:longitude":173.946646,
     "iso:country":"NZ",
+    "label:eng_x_preferred_placetype":[
+        "unitary authority"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "autorit\u00e9 unitaire"
+    ],
     "lbl:latitude":-41.549367,
     "lbl:longitude":173.946618,
     "lbl:max_zoom":13.0,
@@ -62,7 +68,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1695878943,
+    "wof:lastmodified":1696022878,
     "wof:name":"Blenheim",
     "wof:parent_id":102079353,
     "wof:placetype":"localadmin",

--- a/data/172/923/845/7/1729238457.geojson
+++ b/data/172/923/845/7/1729238457.geojson
@@ -5,11 +5,17 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.004869,
-    "geom:area_square_m":41917048.601933,
+    "geom:area_square_m":41917048.601818,
     "geom:bbox":"170.285534,-45.907987,170.408798,-45.837988",
     "geom:latitude":-45.871852,
     "geom:longitude":170.345389,
     "iso:country":"NZ",
+    "label:eng_x_preferred_placetype":[
+        "territorial authority district"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "autorit\u00e9 territoriale"
+    ],
     "lbl:latitude":-45.876409,
     "lbl:longitude":170.336046,
     "lbl:max_zoom":13.0,
@@ -37,7 +43,7 @@
     ],
     "wof:country":"NZ",
     "wof:created":1600724616,
-    "wof:geomhash":"f917c8de853224b0d8c983de2d9529f9",
+    "wof:geomhash":"8566884c577a6806dd3c77eae4b7a7ef",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -56,7 +62,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1617130277,
+    "wof:lastmodified":1695878937,
     "wof:name":"Mosgiel",
     "wof:parent_id":102079387,
     "wof:placetype":"localadmin",

--- a/data/172/923/845/9/1729238459.geojson
+++ b/data/172/923/845/9/1729238459.geojson
@@ -5,11 +5,17 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.001009,
-    "geom:area_square_m":9038026.724488,
+    "geom:area_square_m":9038026.724497,
     "geom:bbox":"172.681286,-43.613114,172.75979,-43.587682",
     "geom:latitude":-43.59917,
     "geom:longitude":172.71497,
     "iso:country":"NZ",
+    "label:eng_x_preferred_placetype":[
+        "territorial authority district"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "autorit\u00e9 territoriale"
+    ],
     "lbl:latitude":-43.596867,
     "lbl:longitude":172.722068,
     "lbl:max_zoom":13.0,
@@ -37,7 +43,7 @@
     ],
     "wof:country":"NZ",
     "wof:created":1600724617,
-    "wof:geomhash":"5ad4fc58921fce41eed4c55ede6993f8",
+    "wof:geomhash":"2535c326f375e26a6c5ed23e542f0bfa",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -56,7 +62,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1617131110,
+    "wof:lastmodified":1695878940,
     "wof:name":"Lyttelton",
     "wof:parent_id":102079401,
     "wof:placetype":"localadmin",

--- a/data/172/923/846/1/1729238461.geojson
+++ b/data/172/923/846/1/1729238461.geojson
@@ -5,11 +5,17 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.003317,
-    "geom:area_square_m":31018501.293277,
+    "geom:area_square_m":31018501.293471,
     "geom:bbox":"175.006966,-40.908925,175.100369,-40.838602",
     "geom:latitude":-40.870418,
     "geom:longitude":175.060775,
     "iso:country":"NZ",
+    "label:eng_x_preferred_placetype":[
+        "territorial authority district"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "autorit\u00e9 territoriale"
+    ],
     "lbl:latitude":-40.866719,
     "lbl:longitude":175.067813,
     "lbl:max_zoom":13.0,
@@ -37,7 +43,7 @@
     ],
     "wof:country":"NZ",
     "wof:created":1600724618,
-    "wof:geomhash":"de83ab6b16840e5bc216d94e208bc782",
+    "wof:geomhash":"e9a442bd17195343989fd18b4e9f7d38",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -56,7 +62,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1603139789,
+    "wof:lastmodified":1695878919,
     "wof:name":"Waikanae",
     "wof:parent_id":102079315,
     "wof:placetype":"localadmin",

--- a/data/172/923/846/5/1729238465.geojson
+++ b/data/172/923/846/5/1729238465.geojson
@@ -5,11 +5,17 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.006903,
-    "geom:area_square_m":64501678.730941,
+    "geom:area_square_m":64501678.730356,
     "geom:bbox":"174.97228,-40.973652,175.076804,-40.871394",
     "geom:latitude":-40.920635,
     "geom:longitude":175.019549,
     "iso:country":"NZ",
+    "label:eng_x_preferred_placetype":[
+        "territorial authority district"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "autorit\u00e9 territoriale"
+    ],
     "lbl:latitude":-40.918723,
     "lbl:longitude":175.01855,
     "lbl:max_zoom":13.0,
@@ -85,7 +91,7 @@
     ],
     "wof:country":"NZ",
     "wof:created":1600724618,
-    "wof:geomhash":"a80ab0f3d680b325a3396c7f5d42b122",
+    "wof:geomhash":"ead3deb75d0346ff938611c63c38da5c",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -104,7 +110,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1636495087,
+    "wof:lastmodified":1695878951,
     "wof:name":"Paraparaumu",
     "wof:parent_id":102079315,
     "wof:placetype":"localadmin",

--- a/data/172/923/846/7/1729238467.geojson
+++ b/data/172/923/846/7/1729238467.geojson
@@ -5,11 +5,17 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.00097,
-    "geom:area_square_m":9627298.829918,
+    "geom:area_square_m":9627298.829959,
     "geom:bbox":"174.661393,-36.600225,174.700951,-36.559733",
     "geom:latitude":-36.580567,
     "geom:longitude":174.681413,
     "iso:country":"NZ",
+    "label:eng_x_preferred_placetype":[
+        "territorial authority district"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "autorit\u00e9 territoriale"
+    ],
     "lbl:latitude":-36.580325,
     "lbl:longitude":174.681414,
     "lbl:max_zoom":13.0,
@@ -37,7 +43,7 @@
     ],
     "wof:country":"NZ",
     "wof:created":1600724619,
-    "wof:geomhash":"d043bf5d94518cbc1eb431ae0f3a807c",
+    "wof:geomhash":"3dc2dffd37fd8fb4dbb8d3307e246e4c",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -56,7 +62,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1617129923,
+    "wof:lastmodified":1695878935,
     "wof:name":"Orewa",
     "wof:parent_id":102079403,
     "wof:placetype":"localadmin",

--- a/data/172/923/846/9/1729238469.geojson
+++ b/data/172/923/846/9/1729238469.geojson
@@ -5,11 +5,17 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.001339,
-    "geom:area_square_m":13220868.705846,
+    "geom:area_square_m":13220868.705942,
     "geom:bbox":"174.899558,-37.05963,174.968721,-37.014676",
     "geom:latitude":-37.036119,
     "geom:longitude":174.93136,
     "iso:country":"NZ",
+    "label:eng_x_preferred_placetype":[
+        "territorial authority district"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "autorit\u00e9 territoriale"
+    ],
     "lbl:latitude":-37.03696,
     "lbl:longitude":174.931763,
     "lbl:max_zoom":13.0,
@@ -37,7 +43,7 @@
     ],
     "wof:country":"NZ",
     "wof:created":1600724620,
-    "wof:geomhash":"fa1123dec44be02c8edae74a28e87deb",
+    "wof:geomhash":"cb146a97052fe72c053b4e316fbf7c3a",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -56,7 +62,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1603221000,
+    "wof:lastmodified":1695878923,
     "wof:name":"Takanini",
     "wof:parent_id":102079403,
     "wof:placetype":"localadmin",

--- a/data/172/923/847/1/1729238471.geojson
+++ b/data/172/923/847/1/1729238471.geojson
@@ -5,11 +5,17 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.046199,
-    "geom:area_square_m":421075431.187454,
+    "geom:area_square_m":421075431.187697,
     "geom:bbox":"172.535489,-42.630337,172.937729,-42.407519",
     "geom:latitude":-42.514492,
     "geom:longitude":172.745589,
     "iso:country":"NZ",
+    "label:eng_x_preferred_placetype":[
+        "territorial authority district"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "autorit\u00e9 territoriale"
+    ],
     "lbl:latitude":-42.488299,
     "lbl:longitude":172.725898,
     "lbl:max_zoom":13.0,
@@ -37,7 +43,7 @@
     ],
     "wof:country":"NZ",
     "wof:created":1600724621,
-    "wof:geomhash":"2da139fb3fa3092bff9291e8e231ebdc",
+    "wof:geomhash":"adb26c685516ec35f7800b0fd9c74888",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -56,7 +62,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1617130008,
+    "wof:lastmodified":1695878935,
     "wof:name":"Hanmer Springs",
     "wof:parent_id":102079365,
     "wof:placetype":"localadmin",

--- a/data/172/923/847/3/1729238473.geojson
+++ b/data/172/923/847/3/1729238473.geojson
@@ -5,11 +5,17 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.006153,
-    "geom:area_square_m":58586444.346006,
+    "geom:area_square_m":58586444.345936,
     "geom:bbox":"176.75275,-39.685596,176.876375,-39.593429",
     "geom:latitude":-39.641229,
     "geom:longitude":176.820741,
     "iso:country":"NZ",
+    "label:eng_x_preferred_placetype":[
+        "territorial authority district"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "autorit\u00e9 territoriale"
+    ],
     "lbl:latitude":-39.645178,
     "lbl:longitude":176.826789,
     "lbl:max_zoom":13.0,
@@ -43,7 +49,7 @@
     ],
     "wof:country":"NZ",
     "wof:created":1600724622,
-    "wof:geomhash":"03f6b97e409b0e3d58ca8cf069947eb7",
+    "wof:geomhash":"19928317ca3c1cf9e8ac050b7429895b",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -62,7 +68,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1636495090,
+    "wof:lastmodified":1695878954,
     "wof:name":"Hastings",
     "wof:parent_id":102079329,
     "wof:placetype":"localadmin",

--- a/data/172/923/847/5/1729238475.geojson
+++ b/data/172/923/847/5/1729238475.geojson
@@ -5,11 +5,17 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.017809,
-    "geom:area_square_m":169786688.138565,
+    "geom:area_square_m":169786688.138459,
     "geom:bbox":"174.214933,-39.652713,174.376696,-39.464623",
     "geom:latitude":-39.554492,
     "geom:longitude":174.299432,
     "iso:country":"NZ",
+    "label:eng_x_preferred_placetype":[
+        "territorial authority district"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "autorit\u00e9 territoriale"
+    ],
     "lbl:latitude":-39.554317,
     "lbl:longitude":174.299459,
     "lbl:max_zoom":13.0,
@@ -88,7 +94,7 @@
     ],
     "wof:country":"NZ",
     "wof:created":1600724623,
-    "wof:geomhash":"679228f8f9806f02e92ef5d25f78cb09",
+    "wof:geomhash":"0d605b9edc59ea1bd859a226c054d8ea",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -107,7 +113,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1636495090,
+    "wof:lastmodified":1695878954,
     "wof:name":"Hawera",
     "wof:parent_id":102079295,
     "wof:placetype":"localadmin",

--- a/data/172/923/847/7/1729238477.geojson
+++ b/data/172/923/847/7/1729238477.geojson
@@ -5,11 +5,17 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.0139,
-    "geom:area_square_m":137823432.42984,
+    "geom:area_square_m":137823432.429849,
     "geom:bbox":"174.373186,-36.747221,174.558397,-36.630889",
     "geom:latitude":-36.691085,
     "geom:longitude":174.468914,
     "iso:country":"NZ",
+    "label:eng_x_preferred_placetype":[
+        "territorial authority district"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "autorit\u00e9 territoriale"
+    ],
     "lbl:latitude":-36.692057,
     "lbl:longitude":174.467135,
     "lbl:max_zoom":13.0,
@@ -37,7 +43,7 @@
     ],
     "wof:country":"NZ",
     "wof:created":1600724624,
-    "wof:geomhash":"8cce2dff3529a4ef23ca9310719e9af8",
+    "wof:geomhash":"e3c6dc30bee65b0cbaf752f83e3adecd",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -56,7 +62,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1603139871,
+    "wof:lastmodified":1695878919,
     "wof:name":"Helensville",
     "wof:parent_id":102079403,
     "wof:placetype":"localadmin",

--- a/data/172/923/847/9/1729238479.geojson
+++ b/data/172/923/847/9/1729238479.geojson
@@ -5,11 +5,17 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.003189,
-    "geom:area_square_m":28969860.896949,
+    "geom:area_square_m":28969860.896804,
     "geom:bbox":"170.946984,-42.759832,171.049547,-42.699983",
     "geom:latitude":-42.729857,
     "geom:longitude":171.006399,
     "iso:country":"NZ",
+    "label:eng_x_preferred_placetype":[
+        "territorial authority district"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "autorit\u00e9 territoriale"
+    ],
     "lbl:latitude":-42.728404,
     "lbl:longitude":171.009865,
     "lbl:max_zoom":13.0,
@@ -67,7 +73,7 @@
     ],
     "wof:country":"NZ",
     "wof:created":1600724625,
-    "wof:geomhash":"be6cfe201f669dae2e4f8f6a203a477b",
+    "wof:geomhash":"f841800d09855293b1cefe1dbde7c2f2",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -86,7 +92,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1636495089,
+    "wof:lastmodified":1695878953,
     "wof:name":"Hokitika",
     "wof:parent_id":102079363,
     "wof:placetype":"localadmin",

--- a/data/172/923/848/3/1729238483.geojson
+++ b/data/172/923/848/3/1729238483.geojson
@@ -5,11 +5,17 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.013228,
-    "geom:area_square_m":112749800.002105,
+    "geom:area_square_m":112749800.002018,
     "geom:bbox":"168.314112,-46.503741,168.465303,-46.336514",
     "geom:latitude":-46.425452,
     "geom:longitude":168.391492,
     "iso:country":"NZ",
+    "label:eng_x_preferred_placetype":[
+        "territorial authority district"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "autorit\u00e9 territoriale"
+    ],
     "lbl:latitude":-46.447664,
     "lbl:longitude":168.396618,
     "lbl:max_zoom":13.0,
@@ -40,7 +46,7 @@
     ],
     "wof:country":"NZ",
     "wof:created":1600724626,
-    "wof:geomhash":"b22cb79ca0a808584643a175d4c90935",
+    "wof:geomhash":"e88bcba0fe0e309790a51d6f1e6be138",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -59,7 +65,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1636495088,
+    "wof:lastmodified":1695878952,
     "wof:name":"Invercargill",
     "wof:parent_id":102079397,
     "wof:placetype":"localadmin",

--- a/data/172/923/848/5/1729238485.geojson
+++ b/data/172/923/848/5/1729238485.geojson
@@ -5,11 +5,17 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.016442,
-    "geom:area_square_m":154716600.353966,
+    "geom:area_square_m":154716600.353948,
     "geom:bbox":"175.212816,-40.517248,175.425865,-40.385953",
     "geom:latitude":-40.448999,
     "geom:longitude":175.302483,
     "iso:country":"NZ",
+    "label:eng_x_preferred_placetype":[
+        "territorial authority district"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "autorit\u00e9 territoriale"
+    ],
     "lbl:latitude":-40.447258,
     "lbl:longitude":175.304065,
     "lbl:max_zoom":13.0,
@@ -37,7 +43,7 @@
     ],
     "wof:country":"NZ",
     "wof:created":1600724627,
-    "wof:geomhash":"aedc169fd27246edaa2e6f4940076e02",
+    "wof:geomhash":"a0233b160ac8f6cb5768281031acb925",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -56,7 +62,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1617130367,
+    "wof:lastmodified":1695878939,
     "wof:name":"Foxton",
     "wof:parent_id":102079313,
     "wof:placetype":"localadmin",

--- a/data/172/923/848/7/1729238487.geojson
+++ b/data/172/923/848/7/1729238487.geojson
@@ -11,9 +11,12 @@
     "geom:longitude":177.967012,
     "iso:country":"NZ",
     "label:eng_x_preferred_placetype":[
-        "territorial authority district"
+        "unitary authority"
     ],
     "label:fra_x_preferred_placetype":[
+        "autorit\u00e9 unitaire"
+    ],
+    "label:fra_x_variant_placetype":[
         "autorit\u00e9 territoriale"
     ],
     "lbl:latitude":-38.638119,
@@ -68,7 +71,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1695878952,
+    "wof:lastmodified":1696022882,
     "wof:name":"Gisborne",
     "wof:parent_id":102079325,
     "wof:placetype":"localadmin",

--- a/data/172/923/848/7/1729238487.geojson
+++ b/data/172/923/848/7/1729238487.geojson
@@ -5,11 +5,17 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.015107,
-    "geom:area_square_m":145909641.013956,
+    "geom:area_square_m":145909641.013856,
     "geom:bbox":"177.849941,-38.716217,178.106324,-38.555393",
     "geom:latitude":-38.641267,
     "geom:longitude":177.967012,
     "iso:country":"NZ",
+    "label:eng_x_preferred_placetype":[
+        "territorial authority district"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "autorit\u00e9 territoriale"
+    ],
     "lbl:latitude":-38.638119,
     "lbl:longitude":177.954402,
     "lbl:max_zoom":13.0,
@@ -43,7 +49,7 @@
     ],
     "wof:country":"NZ",
     "wof:created":1600724628,
-    "wof:geomhash":"7b6b5ee2d3703f0d9f0c10e99ecd606c",
+    "wof:geomhash":"be07af0681beba10e170a50bbec4f480",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -62,7 +68,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1636495087,
+    "wof:lastmodified":1695878952,
     "wof:name":"Gisborne",
     "wof:parent_id":102079325,
     "wof:placetype":"localadmin",

--- a/data/172/923/848/9/1729238489.geojson
+++ b/data/172/923/848/9/1729238489.geojson
@@ -5,11 +5,17 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.003018,
-    "geom:area_square_m":25868721.474774,
+    "geom:area_square_m":25868721.474815,
     "geom:bbox":"168.881601,-46.17422,168.982992,-46.07845",
     "geom:latitude":-46.123281,
     "geom:longitude":168.928253,
     "iso:country":"NZ",
+    "label:eng_x_preferred_placetype":[
+        "territorial authority district"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "autorit\u00e9 territoriale"
+    ],
     "lbl:latitude":-46.103571,
     "lbl:longitude":168.940091,
     "lbl:max_zoom":13.0,
@@ -85,7 +91,7 @@
     ],
     "wof:country":"NZ",
     "wof:created":1600724629,
-    "wof:geomhash":"03fe2386abd200acbbcd4d01d63d29e7",
+    "wof:geomhash":"e3fe8db4ee98236b09040db29bca20c3",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -104,7 +110,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1636495087,
+    "wof:lastmodified":1695878952,
     "wof:name":"Gore",
     "wof:parent_id":102079393,
     "wof:placetype":"localadmin",

--- a/data/172/923/849/1/1729238491.geojson
+++ b/data/172/923/849/1/1729238491.geojson
@@ -10,6 +10,12 @@
     "geom:latitude":-42.48824,
     "geom:longitude":171.2549,
     "iso:country":"NZ",
+    "label:eng_x_preferred_placetype":[
+        "territorial authority district"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "autorit\u00e9 territoriale"
+    ],
     "lbl:latitude":-42.468796,
     "lbl:longitude":171.252442,
     "lbl:max_zoom":13.0,
@@ -77,7 +83,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1695878953,
+    "wof:lastmodified":1696022882,
     "wof:name":"Greymouth",
     "wof:parent_id":102079361,
     "wof:placetype":"localadmin",

--- a/data/172/923/849/1/1729238491.geojson
+++ b/data/172/923/849/1/1729238491.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.048426,
-    "geom:area_square_m":441564198.313921,
+    "geom:area_square_m":441564198.315595,
     "geom:bbox":"171.092617,-42.730128,171.426092,-42.312388",
     "geom:latitude":-42.48824,
     "geom:longitude":171.2549,
@@ -58,7 +58,7 @@
     ],
     "wof:country":"NZ",
     "wof:created":1600724629,
-    "wof:geomhash":"f36e1bf30a2f0b60003169fcede293c1",
+    "wof:geomhash":"e00ae0ccc94f55caa9841069876040db",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -77,7 +77,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1636495088,
+    "wof:lastmodified":1695878953,
     "wof:name":"Greymouth",
     "wof:parent_id":102079361,
     "wof:placetype":"localadmin",

--- a/data/172/923/849/3/1729238493.geojson
+++ b/data/172/923/849/3/1729238493.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.01882,
-    "geom:area_square_m":183929136.242359,
+    "geom:area_square_m":183929136.242107,
     "geom:bbox":"175.151382,-37.85155,175.544165,-37.704092",
     "geom:latitude":-37.779713,
     "geom:longitude":175.313656,
@@ -432,7 +432,7 @@
     ],
     "wof:country":"NZ",
     "wof:created":1600724630,
-    "wof:geomhash":"78dd63568347ce80f82771dbc37e69a4",
+    "wof:geomhash":"6c6633b0aab063e01b070b92ac66e08f",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -451,7 +451,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1690849960,
+    "wof:lastmodified":1695878954,
     "wof:name":"Hamilton",
     "wof:parent_id":102079271,
     "wof:placetype":"localadmin",

--- a/data/172/923/849/3/1729238493.geojson
+++ b/data/172/923/849/3/1729238493.geojson
@@ -11,6 +11,12 @@
     "geom:longitude":175.313656,
     "gn:id":"2190324,6697408",
     "iso:country":"NZ",
+    "label:eng_x_preferred_placetype":[
+        "territorial authority city"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "collectivit\u00e9 territoriale ville"
+    ],
     "lbl:latitude":-37.764577,
     "lbl:longitude":175.269615,
     "lbl:max_zoom":13.0,
@@ -451,7 +457,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1695878954,
+    "wof:lastmodified":1696022883,
     "wof:name":"Hamilton",
     "wof:parent_id":102079271,
     "wof:placetype":"localadmin",

--- a/data/172/923/849/5/1729238495.geojson
+++ b/data/172/923/849/5/1729238495.geojson
@@ -5,12 +5,18 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.023584,
-    "geom:area_square_m":203019783.809753,
+    "geom:area_square_m":203019783.809552,
     "geom:bbox":"170.247302,-45.96919,170.683577,-45.796627",
     "geom:latitude":-45.879847,
     "geom:longitude":170.479075,
     "gn:population":114347,
     "iso:country":"NZ",
+    "label:eng_x_preferred_placetype":[
+        "territorial authority district"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "autorit\u00e9 territoriale"
+    ],
     "lbl:latitude":-45.884331,
     "lbl:longitude":170.46444,
     "lbl:max_zoom":14.0,
@@ -316,7 +322,7 @@
     ],
     "wof:country":"NZ",
     "wof:created":1600724631,
-    "wof:geomhash":"af4cdfec153de341963e6b0f9054d698",
+    "wof:geomhash":"2eabccd20e38daf4693824acc583f139",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -335,7 +341,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1690849961,
+    "wof:lastmodified":1695878941,
     "wof:name":"Dunedin",
     "wof:parent_id":102079387,
     "wof:placetype":"localadmin",

--- a/data/172/923/849/7/1729238497.geojson
+++ b/data/172/923/849/7/1729238497.geojson
@@ -10,6 +10,12 @@
     "geom:latitude":-46.605974,
     "geom:longitude":168.328497,
     "iso:country":"NZ",
+    "label:eng_x_preferred_placetype":[
+        "territorial authority district"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "autorit\u00e9 territoriale"
+    ],
     "lbl:latitude":-46.611227,
     "lbl:longitude":168.335464,
     "lbl:max_zoom":13.0,
@@ -56,7 +62,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1695878919,
+    "wof:lastmodified":1696022867,
     "wof:name":"Bluff",
     "wof:parent_id":102079397,
     "wof:placetype":"localadmin",

--- a/data/172/923/849/7/1729238497.geojson
+++ b/data/172/923/849/7/1729238497.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.001246,
-    "geom:area_square_m":10586956.174383,
+    "geom:area_square_m":10586956.174366,
     "geom:bbox":"168.276752,-46.625585,168.360165,-46.584216",
     "geom:latitude":-46.605974,
     "geom:longitude":168.328497,
@@ -37,7 +37,7 @@
     ],
     "wof:country":"NZ",
     "wof:created":1600724633,
-    "wof:geomhash":"98b64e3d943e1cf2c492834b0203adaf",
+    "wof:geomhash":"9382d594f6a086327b592511fe0756e0",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -56,7 +56,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1603139937,
+    "wof:lastmodified":1695878919,
     "wof:name":"Bluff",
     "wof:parent_id":102079397,
     "wof:placetype":"localadmin",

--- a/data/172/923/850/1/1729238501.geojson
+++ b/data/172/923/850/1/1729238501.geojson
@@ -5,11 +5,17 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.012942,
-    "geom:area_square_m":122261348.436596,
+    "geom:area_square_m":122261348.43654,
     "geom:bbox":"175.219676,-40.244257,175.436284,-40.125667",
     "geom:latitude":-40.185182,
     "geom:longitude":175.338644,
     "iso:country":"NZ",
+    "label:eng_x_preferred_placetype":[
+        "territorial authority district"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "autorit\u00e9 territoriale"
+    ],
     "lbl:latitude":-40.18133,
     "lbl:longitude":175.329654,
     "lbl:max_zoom":13.0,
@@ -37,7 +43,7 @@
     ],
     "wof:country":"NZ",
     "wof:created":1600724633,
-    "wof:geomhash":"8f5c7b265236b007ccdce46423313f02",
+    "wof:geomhash":"4001ae0854c20eaf870f7672f4da5600",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -56,7 +62,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1603139939,
+    "wof:lastmodified":1695878919,
     "wof:name":"Bulls",
     "wof:parent_id":102079301,
     "wof:placetype":"localadmin",

--- a/data/172/923/850/3/1729238503.geojson
+++ b/data/172/923/850/3/1729238503.geojson
@@ -5,11 +5,17 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.011245,
-    "geom:area_square_m":109720146.651194,
+    "geom:area_square_m":109720146.651098,
     "geom:bbox":"175.403109,-37.960052,175.551067,-37.825613",
     "geom:latitude":-37.899228,
     "geom:longitude":175.478273,
     "iso:country":"NZ",
+    "label:eng_x_preferred_placetype":[
+        "territorial authority district"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "autorit\u00e9 territoriale"
+    ],
     "lbl:latitude":-37.898511,
     "lbl:longitude":175.489426,
     "lbl:max_zoom":13.0,
@@ -64,7 +70,7 @@
     ],
     "wof:country":"NZ",
     "wof:created":1600724634,
-    "wof:geomhash":"29af5f8f16e57606a47360f305e506ef",
+    "wof:geomhash":"83927a5b4dca3303dc666f17bb11f8ab",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -83,7 +89,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1636495082,
+    "wof:lastmodified":1695878946,
     "wof:name":"Cambridge",
     "wof:parent_id":102079273,
     "wof:placetype":"localadmin",

--- a/data/172/923/850/5/1729238505.geojson
+++ b/data/172/923/850/5/1729238505.geojson
@@ -5,11 +5,17 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.001939,
-    "geom:area_square_m":18091625.190276,
+    "geom:area_square_m":18091625.190285,
     "geom:bbox":"175.491819,-41.059977,175.5703,-40.995253",
     "geom:latitude":-41.022503,
     "geom:longitude":175.528037,
     "iso:country":"NZ",
+    "label:eng_x_preferred_placetype":[
+        "territorial authority district"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "autorit\u00e9 territoriale"
+    ],
     "lbl:latitude":-41.022695,
     "lbl:longitude":175.52423,
     "lbl:max_zoom":13.0,
@@ -37,7 +43,7 @@
     ],
     "wof:country":"NZ",
     "wof:created":1600724635,
-    "wof:geomhash":"a04fecbbaca599baf7daaca4c9599cc7",
+    "wof:geomhash":"8b55346e0a466bc19a7202487b697118",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -56,7 +62,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1603139967,
+    "wof:lastmodified":1695878919,
     "wof:name":"Carterton",
     "wof:parent_id":102079345,
     "wof:placetype":"localadmin",

--- a/data/172/923/850/7/1729238507.geojson
+++ b/data/172/923/850/7/1729238507.geojson
@@ -11,6 +11,12 @@
     "geom:longitude":172.597018,
     "gn:population":363926,
     "iso:country":"NZ",
+    "label:eng_x_preferred_placetype":[
+        "territorial authority city"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "collectivit\u00e9 territoriale ville"
+    ],
     "lbl:latitude":-43.523242,
     "lbl:longitude":172.600406,
     "lbl:max_zoom":13.0,
@@ -448,7 +454,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1695878942,
+    "wof:lastmodified":1696022878,
     "wof:name":"Christchurch",
     "wof:parent_id":102079401,
     "wof:placetype":"localadmin",

--- a/data/172/923/850/7/1729238507.geojson
+++ b/data/172/923/850/7/1729238507.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.050813,
-    "geom:area_square_m":455655762.002569,
+    "geom:area_square_m":455655762.003528,
     "geom:bbox":"172.38909,-43.635521,172.808913,-43.388764",
     "geom:latitude":-43.514009,
     "geom:longitude":172.597018,
@@ -429,7 +429,7 @@
     ],
     "wof:country":"NZ",
     "wof:created":1600724636,
-    "wof:geomhash":"4cd812bc6ab04315e2700455a58e9c93",
+    "wof:geomhash":"6a245ad089604f293d3867f55219dfa9",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -448,7 +448,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1690849957,
+    "wof:lastmodified":1695878942,
     "wof:name":"Christchurch",
     "wof:parent_id":102079401,
     "wof:placetype":"localadmin",

--- a/data/172/923/850/9/1729238509.geojson
+++ b/data/172/923/850/9/1729238509.geojson
@@ -5,11 +5,17 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.007036,
-    "geom:area_square_m":69703242.696076,
+    "geom:area_square_m":69703242.696036,
     "geom:bbox":"175.462503,-36.825575,175.612505,-36.705524",
     "geom:latitude":-36.757312,
     "geom:longitude":175.539047,
     "iso:country":"NZ",
+    "label:eng_x_preferred_placetype":[
+        "territorial authority district"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "autorit\u00e9 territoriale"
+    ],
     "lbl:latitude":-36.744395,
     "lbl:longitude":175.507952,
     "lbl:max_zoom":13.0,
@@ -73,7 +79,7 @@
     ],
     "wof:country":"NZ",
     "wof:created":1600724637,
-    "wof:geomhash":"1da55544dd3e2ac991707c2750eff5d0",
+    "wof:geomhash":"cf9fdc5ef63cab8e4b62e67acf232874",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -92,7 +98,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1636495081,
+    "wof:lastmodified":1695878945,
     "wof:name":"Coromandel",
     "wof:parent_id":102079261,
     "wof:placetype":"localadmin",

--- a/data/172/923/851/1/1729238511.geojson
+++ b/data/172/923/851/1/1729238511.geojson
@@ -5,12 +5,18 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.01106,
-    "geom:area_square_m":105525146.229027,
+    "geom:area_square_m":105525146.228408,
     "geom:bbox":"176.809277,-39.570451,176.928148,-39.388665",
     "geom:latitude":-39.500305,
     "geom:longitude":176.869239,
     "gn:population":56787,
     "iso:country":"NZ",
+    "label:eng_x_preferred_placetype":[
+        "territorial authority district"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "autorit\u00e9 territoriale"
+    ],
     "lbl:latitude":-39.524326,
     "lbl:longitude":176.88404,
     "lbl:max_zoom":14.0,
@@ -337,7 +343,7 @@
     },
     "wof:country":"NZ",
     "wof:created":1600724638,
-    "wof:geomhash":"57204d7f15decda23032bab5395ace90",
+    "wof:geomhash":"cdf566c631d6b4b8903a1f2f5d144e76",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -356,7 +362,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1690849957,
+    "wof:lastmodified":1695878942,
     "wof:name":"Napier",
     "wof:parent_id":102079331,
     "wof:placetype":"localadmin",

--- a/data/172/923/851/3/1729238513.geojson
+++ b/data/172/923/851/3/1729238513.geojson
@@ -11,10 +11,10 @@
     "geom:longitude":173.314314,
     "iso:country":"NZ",
     "label:eng_x_preferred_placetype":[
-        "territorial authority district"
+        "unitary authority"
     ],
     "label:fra_x_preferred_placetype":[
-        "autorit\u00e9 territoriale"
+        "autorit\u00e9 unitaire"
     ],
     "lbl:latitude":-41.298774,
     "lbl:longitude":173.294667,
@@ -77,7 +77,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1695878946,
+    "wof:lastmodified":1696022879,
     "wof:name":"Nelson",
     "wof:parent_id":102079351,
     "wof:placetype":"localadmin",

--- a/data/172/923/851/3/1729238513.geojson
+++ b/data/172/923/851/3/1729238513.geojson
@@ -5,11 +5,17 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.014248,
-    "geom:area_square_m":132347164.045153,
+    "geom:area_square_m":132347164.044938,
     "geom:bbox":"173.204779,-41.372216,173.421239,-41.222783",
     "geom:latitude":-41.306431,
     "geom:longitude":173.314314,
     "iso:country":"NZ",
+    "label:eng_x_preferred_placetype":[
+        "territorial authority district"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "autorit\u00e9 territoriale"
+    ],
     "lbl:latitude":-41.298774,
     "lbl:longitude":173.294667,
     "lbl:max_zoom":13.0,
@@ -52,7 +58,7 @@
     ],
     "wof:country":"NZ",
     "wof:created":1600724639,
-    "wof:geomhash":"0b06cb7502dec3f8df0cfc7880bdca25",
+    "wof:geomhash":"2fd06f3fdd78366b695de90ecf85403d",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -71,7 +77,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1636495082,
+    "wof:lastmodified":1695878946,
     "wof:name":"Nelson",
     "wof:parent_id":102079351,
     "wof:placetype":"localadmin",

--- a/data/172/923/851/5/1729238515.geojson
+++ b/data/172/923/851/5/1729238515.geojson
@@ -5,11 +5,17 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.005576,
-    "geom:area_square_m":53536087.136452,
+    "geom:area_square_m":53536087.136571,
     "geom:bbox":"174.018553,-39.109938,174.185187,-39.013008",
     "geom:latitude":-39.062939,
     "geom:longitude":174.091029,
     "iso:country":"NZ",
+    "label:eng_x_preferred_placetype":[
+        "territorial authority district"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "autorit\u00e9 territoriale"
+    ],
     "lbl:latitude":-39.072184,
     "lbl:longitude":174.077146,
     "lbl:max_zoom":13.0,
@@ -40,7 +46,7 @@
     ],
     "wof:country":"NZ",
     "wof:created":1600724640,
-    "wof:geomhash":"14a1e7295f2d8b4ac9826e6156973eca",
+    "wof:geomhash":"efa9ae43a46fdbf9afa1d1bd8a4b3d8c",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -59,7 +65,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1636495082,
+    "wof:lastmodified":1695878947,
     "wof:name":"New Plymouth",
     "wof:parent_id":102079311,
     "wof:placetype":"localadmin",

--- a/data/172/923/851/9/1729238519.geojson
+++ b/data/172/923/851/9/1729238519.geojson
@@ -5,11 +5,17 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.198666,
-    "geom:area_square_m":1675767257.580432,
+    "geom:area_square_m":1675767257.581955,
     "geom:bbox":"167.447215,-47.290001,168.229268,-46.683608",
     "geom:latitude":-46.98668,
     "geom:longitude":167.858352,
     "iso:country":"NZ",
+    "label:eng_x_preferred_placetype":[
+        "territorial authority district"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "autorit\u00e9 territoriale"
+    ],
     "lbl:latitude":-47.051655,
     "lbl:longitude":167.825887,
     "lbl:max_zoom":13.0,
@@ -34,7 +40,7 @@
     "wof:breaches":[],
     "wof:country":"NZ",
     "wof:created":1600724641,
-    "wof:geomhash":"424f5c522bfb072e0349ba2df49b71e3",
+    "wof:geomhash":"f709e8ee5a30bcf62046fa8cd84b949b",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -53,7 +59,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1603140089,
+    "wof:lastmodified":1695878919,
     "wof:name":"Stewart Island",
     "wof:parent_id":102079391,
     "wof:placetype":"localadmin",

--- a/data/172/923/852/1/1729238521.geojson
+++ b/data/172/923/852/1/1729238521.geojson
@@ -5,11 +5,17 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.005561,
-    "geom:area_square_m":48557721.448009,
+    "geom:area_square_m":48557721.447999,
     "geom:bbox":"170.897807,-45.122193,171.01932,-45.024824",
     "geom:latitude":-45.072637,
     "geom:longitude":170.950547,
     "iso:country":"NZ",
+    "label:eng_x_preferred_placetype":[
+        "territorial authority district"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "autorit\u00e9 territoriale"
+    ],
     "lbl:latitude":-45.081738,
     "lbl:longitude":170.944563,
     "lbl:max_zoom":13.0,
@@ -76,7 +82,7 @@
     ],
     "wof:country":"NZ",
     "wof:created":1600724643,
-    "wof:geomhash":"68f3e92cc9910b6acc2866ec100a0003",
+    "wof:geomhash":"106362726b340423bce0ad07a3bdd8b5",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -95,7 +101,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1636495093,
+    "wof:lastmodified":1695878956,
     "wof:name":"Oamaru",
     "wof:parent_id":102079381,
     "wof:placetype":"localadmin",

--- a/data/172/923/852/3/1729238523.geojson
+++ b/data/172/923/852/3/1729238523.geojson
@@ -5,11 +5,17 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.007228,
-    "geom:area_square_m":70413072.803281,
+    "geom:area_square_m":70413072.803247,
     "geom:bbox":"177.137975,-38.053532,177.302601,-37.987778",
     "geom:latitude":-38.019124,
     "geom:longitude":177.214219,
     "iso:country":"NZ",
+    "label:eng_x_preferred_placetype":[
+        "territorial authority district"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "autorit\u00e9 territoriale"
+    ],
     "lbl:latitude":-38.022378,
     "lbl:longitude":177.223982,
     "lbl:max_zoom":13.0,
@@ -37,7 +43,7 @@
     ],
     "wof:country":"NZ",
     "wof:created":1600724644,
-    "wof:geomhash":"72a8b7ac9039ef914c3238005db545e7",
+    "wof:geomhash":"7d6566f59d93cf93d3004e22c80840d6",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -56,7 +62,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1603140135,
+    "wof:lastmodified":1695878920,
     "wof:name":"Opotiki",
     "wof:parent_id":102079321,
     "wof:placetype":"localadmin",

--- a/data/172/923/852/5/1729238525.geojson
+++ b/data/172/923/852/5/1729238525.geojson
@@ -5,11 +5,17 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.029067,
-    "geom:area_square_m":275174517.037587,
+    "geom:area_square_m":275174517.037406,
     "geom:bbox":"175.293028,-40.152746,175.505557,-39.907399",
     "geom:latitude":-40.039352,
     "geom:longitude":175.391066,
     "iso:country":"NZ",
+    "label:eng_x_preferred_placetype":[
+        "territorial authority district"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "autorit\u00e9 territoriale"
+    ],
     "lbl:latitude":-40.043382,
     "lbl:longitude":175.398355,
     "lbl:max_zoom":13.0,
@@ -37,7 +43,7 @@
     ],
     "wof:country":"NZ",
     "wof:created":1600724645,
-    "wof:geomhash":"d3688585953cc53e70c9ebe66ba739a8",
+    "wof:geomhash":"603ab38cfad55d6f98b9d5547b28bc15",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -56,7 +62,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1603140217,
+    "wof:lastmodified":1695878920,
     "wof:name":"Marton",
     "wof:parent_id":102079301,
     "wof:placetype":"localadmin",

--- a/data/172/923/852/7/1729238527.geojson
+++ b/data/172/923/852/7/1729238527.geojson
@@ -5,11 +5,17 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.011319,
-    "geom:area_square_m":105705305.322099,
+    "geom:area_square_m":105705305.321916,
     "geom:bbox":"175.608085,-41.006448,175.77973,-40.892406",
     "geom:latitude":-40.950881,
     "geom:longitude":175.70066,
     "iso:country":"NZ",
+    "label:eng_x_preferred_placetype":[
+        "territorial authority district"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "autorit\u00e9 territoriale"
+    ],
     "lbl:latitude":-40.953083,
     "lbl:longitude":175.700692,
     "lbl:max_zoom":13.0,
@@ -52,7 +58,7 @@
     ],
     "wof:country":"NZ",
     "wof:created":1600724646,
-    "wof:geomhash":"2d47dcde1dfeba1968df038e4373db5d",
+    "wof:geomhash":"0dff87bda9006a7a24413beef98d7b88",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -71,7 +77,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1636495092,
+    "wof:lastmodified":1695878956,
     "wof:name":"Masterton",
     "wof:parent_id":102079343,
     "wof:placetype":"localadmin",

--- a/data/172/923/852/9/1729238529.geojson
+++ b/data/172/923/852/9/1729238529.geojson
@@ -5,11 +5,17 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.018618,
-    "geom:area_square_m":174819296.277286,
+    "geom:area_square_m":174819296.27801,
     "geom:bbox":"175.183257,-40.679105,175.435128,-40.4747",
     "geom:latitude":-40.592259,
     "geom:longitude":175.284812,
     "iso:country":"NZ",
+    "label:eng_x_preferred_placetype":[
+        "territorial authority district"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "autorit\u00e9 territoriale"
+    ],
     "lbl:latitude":-40.548415,
     "lbl:longitude":175.241326,
     "lbl:max_zoom":13.0,
@@ -88,7 +94,7 @@
     ],
     "wof:country":"NZ",
     "wof:created":1600724646,
-    "wof:geomhash":"507e15827df7258eaee36decfe2f1efe",
+    "wof:geomhash":"26f99fbe96957e1a57adc9ed2f20bfa6",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -107,7 +113,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1636495092,
+    "wof:lastmodified":1695878956,
     "wof:name":"Levin",
     "wof:parent_id":102079313,
     "wof:placetype":"localadmin",

--- a/data/172/923/853/1/1729238531.geojson
+++ b/data/172/923/853/1/1729238531.geojson
@@ -5,11 +5,17 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.009502,
-    "geom:area_square_m":84994645.282034,
+    "geom:area_square_m":84994645.282109,
     "geom:bbox":"172.433474,-43.734434,172.557327,-43.606934",
     "geom:latitude":-43.665366,
     "geom:longitude":172.498045,
     "iso:country":"NZ",
+    "label:eng_x_preferred_placetype":[
+        "territorial authority district"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "autorit\u00e9 territoriale"
+    ],
     "lbl:latitude":-43.664009,
     "lbl:longitude":172.498061,
     "lbl:max_zoom":13.0,
@@ -61,7 +67,7 @@
     ],
     "wof:country":"NZ",
     "wof:created":1600724647,
-    "wof:geomhash":"2e51d8d241ce2bb7d6669a326cf1524c",
+    "wof:geomhash":"39a3b845c7f7aba55ad690c060e5a7ce",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -80,7 +86,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1636495091,
+    "wof:lastmodified":1695878954,
     "wof:name":"Lincoln",
     "wof:parent_id":102079369,
     "wof:placetype":"localadmin",

--- a/data/172/923/853/3/1729238533.geojson
+++ b/data/172/923/853/3/1729238533.geojson
@@ -11,6 +11,12 @@
     "geom:longitude":174.962065,
     "gn:population":101194,
     "iso:country":"NZ",
+    "label:eng_x_preferred_placetype":[
+        "territorial authority city"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "collectivit\u00e9 territoriale ville"
+    ],
     "lbl:latitude":-41.233535,
     "lbl:longitude":174.951936,
     "lbl:max_zoom":14.0,
@@ -258,7 +264,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1695878955,
+    "wof:lastmodified":1696022883,
     "wof:name":"Lower Hutt",
     "wof:parent_id":102079337,
     "wof:placetype":"localadmin",

--- a/data/172/923/853/3/1729238533.geojson
+++ b/data/172/923/853/3/1729238533.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.026762,
-    "geom:area_square_m":248830804.37682,
+    "geom:area_square_m":248830804.377153,
     "geom:bbox":"174.847735,-41.382409,175.087093,-41.132751",
     "geom:latitude":-41.240605,
     "geom:longitude":174.962065,
@@ -239,7 +239,7 @@
     ],
     "wof:country":"NZ",
     "wof:created":1600724649,
-    "wof:geomhash":"57e38774896869844b1ae0ad601026d2",
+    "wof:geomhash":"7d0ba566042d2cc990d26768a9ecaaba",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -258,7 +258,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1690849961,
+    "wof:lastmodified":1695878955,
     "wof:name":"Lower Hutt",
     "wof:parent_id":102079337,
     "wof:placetype":"localadmin",

--- a/data/172/923/853/7/1729238537.geojson
+++ b/data/172/923/853/7/1729238537.geojson
@@ -5,11 +5,17 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.018996,
-    "geom:area_square_m":173661802.368683,
+    "geom:area_square_m":173661802.368585,
     "geom:bbox":"173.450372,-42.437411,173.718565,-42.225011",
     "geom:latitude":-42.325659,
     "geom:longitude":173.601935,
     "iso:country":"NZ",
+    "label:eng_x_preferred_placetype":[
+        "territorial authority district"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "autorit\u00e9 territoriale"
+    ],
     "lbl:latitude":-42.318086,
     "lbl:longitude":173.590776,
     "lbl:max_zoom":13.0,
@@ -67,7 +73,7 @@
     ],
     "wof:country":"NZ",
     "wof:created":1600724651,
-    "wof:geomhash":"679455a415aa3e819e2790564dc70560",
+    "wof:geomhash":"f499106d920291767388cc14fc285728",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -86,7 +92,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1636495091,
+    "wof:lastmodified":1695878955,
     "wof:name":"Kaikoura",
     "wof:parent_id":102079355,
     "wof:placetype":"localadmin",

--- a/data/172/923/853/9/1729238539.geojson
+++ b/data/172/923/853/9/1729238539.geojson
@@ -5,11 +5,17 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.036426,
-    "geom:area_square_m":368312987.055286,
+    "geom:area_square_m":368312987.055537,
     "geom:bbox":"173.055245,-35.252237,173.469121,-35.051074",
     "geom:latitude":-35.143275,
     "geom:longitude":173.26863,
     "iso:country":"NZ",
+    "label:eng_x_preferred_placetype":[
+        "territorial authority district"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "autorit\u00e9 territoriale"
+    ],
     "lbl:latitude":-35.116242,
     "lbl:longitude":173.231047,
     "lbl:max_zoom":13.0,
@@ -82,7 +88,7 @@
     ],
     "wof:country":"NZ",
     "wof:created":1600724652,
-    "wof:geomhash":"944c3c91f4dbaa47c9db0415d17c33a2",
+    "wof:geomhash":"79c2fe37a112e0fd5a77041576c12465",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -101,7 +107,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1636495090,
+    "wof:lastmodified":1695878954,
     "wof:name":"Kaitaia",
     "wof:parent_id":102079255,
     "wof:placetype":"localadmin",

--- a/data/172/923/854/1/1729238541.geojson
+++ b/data/172/923/854/1/1729238541.geojson
@@ -5,11 +5,17 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.012902,
-    "geom:area_square_m":130053806.553205,
+    "geom:area_square_m":130053806.552841,
     "geom:bbox":"173.99735,-35.478239,174.180822,-35.295906",
     "geom:latitude":-35.389769,
     "geom:longitude":174.077084,
     "iso:country":"NZ",
+    "label:eng_x_preferred_placetype":[
+        "territorial authority district"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "autorit\u00e9 territoriale"
+    ],
     "lbl:latitude":-35.400107,
     "lbl:longitude":174.083376,
     "lbl:max_zoom":13.0,
@@ -37,7 +43,7 @@
     ],
     "wof:country":"NZ",
     "wof:created":1600724653,
-    "wof:geomhash":"9c5822ca4be3a61e930af7639f69e889",
+    "wof:geomhash":"b6e17a6410737d65ae44b15dd112b72b",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -56,7 +62,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1617131132,
+    "wof:lastmodified":1695878940,
     "wof:name":"Kawakawa",
     "wof:parent_id":102079255,
     "wof:placetype":"localadmin",

--- a/data/172/923/854/3/1729238543.geojson
+++ b/data/172/923/854/3/1729238543.geojson
@@ -5,11 +5,17 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.074163,
-    "geom:area_square_m":706064267.77514,
+    "geom:area_square_m":706064267.774708,
     "geom:bbox":"175.541539,-39.791937,175.935237,-39.5066",
     "geom:latitude":-39.652001,
     "geom:longitude":175.7284,
     "iso:country":"NZ",
+    "label:eng_x_preferred_placetype":[
+        "territorial authority district"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "autorit\u00e9 territoriale"
+    ],
     "lbl:latitude":-39.626487,
     "lbl:longitude":175.731399,
     "lbl:max_zoom":13.0,
@@ -37,7 +43,7 @@
     ],
     "wof:country":"NZ",
     "wof:created":1600724654,
-    "wof:geomhash":"a1c3b0c87eab868d608667253e82dfe2",
+    "wof:geomhash":"03a2f15e6863322a8ed9708fb3f152f0",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -56,7 +62,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1617131132,
+    "wof:lastmodified":1695878940,
     "wof:name":"Taihape",
     "wof:parent_id":102079301,
     "wof:placetype":"localadmin",

--- a/data/172/923/854/5/1729238545.geojson
+++ b/data/172/923/854/5/1729238545.geojson
@@ -5,11 +5,17 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.000734,
-    "geom:area_square_m":6703185.708283,
+    "geom:area_square_m":6703185.708215,
     "geom:bbox":"171.235905,-42.417054,171.283815,-42.387753",
     "geom:latitude":-42.402279,
     "geom:longitude":171.258938,
     "iso:country":"NZ",
+    "label:eng_x_preferred_placetype":[
+        "territorial authority district"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "autorit\u00e9 territoriale"
+    ],
     "lbl:latitude":-42.400527,
     "lbl:longitude":171.258581,
     "lbl:max_zoom":13.0,
@@ -37,7 +43,7 @@
     ],
     "wof:country":"NZ",
     "wof:created":1600724655,
-    "wof:geomhash":"70de03d3d14d39b329e26031b7483c78",
+    "wof:geomhash":"4200e671b67a205bad53e069104b7148",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -56,7 +62,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1603140311,
+    "wof:lastmodified":1695878920,
     "wof:name":"Runanga",
     "wof:parent_id":102079361,
     "wof:placetype":"localadmin",

--- a/data/172/923/854/7/1729238547.geojson
+++ b/data/172/923/854/7/1729238547.geojson
@@ -5,11 +5,17 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.065737,
-    "geom:area_square_m":632326493.104087,
+    "geom:area_square_m":632326493.10454,
     "geom:bbox":"175.010027,-39.096563,175.424418,-38.785741",
     "geom:latitude":-38.929833,
     "geom:longitude":175.197847,
     "iso:country":"NZ",
+    "label:eng_x_preferred_placetype":[
+        "territorial authority district"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "autorit\u00e9 territoriale"
+    ],
     "lbl:latitude":-38.87388,
     "lbl:longitude":175.182144,
     "lbl:max_zoom":13.0,
@@ -37,7 +43,7 @@
     ],
     "wof:country":"NZ",
     "wof:created":1600724655,
-    "wof:geomhash":"8906292b3f880c576c2e0d21a8237f07",
+    "wof:geomhash":"31bf30a59cf37a31dd1f932584e99233",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -56,7 +62,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1603140324,
+    "wof:lastmodified":1695878921,
     "wof:name":"Taumarunui",
     "wof:parent_id":102079297,
     "wof:placetype":"localadmin",

--- a/data/172/923/854/9/1729238549.geojson
+++ b/data/172/923/854/9/1729238549.geojson
@@ -5,11 +5,17 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.011298,
-    "geom:area_square_m":101660595.570178,
+    "geom:area_square_m":101660595.570219,
     "geom:bbox":"172.425805,-43.359595,172.649743,-43.259198",
     "geom:latitude":-43.306502,
     "geom:longitude":172.540666,
     "iso:country":"NZ",
+    "label:eng_x_preferred_placetype":[
+        "territorial authority district"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "autorit\u00e9 territoriale"
+    ],
     "lbl:latitude":-43.314331,
     "lbl:longitude":172.559312,
     "lbl:max_zoom":13.0,
@@ -37,7 +43,7 @@
     ],
     "wof:country":"NZ",
     "wof:created":1600724657,
-    "wof:geomhash":"e6d1d928e6fdc685a602f2a166b89f49",
+    "wof:geomhash":"3c965c319ca8e97e5f44ee41e96560e7",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -56,7 +62,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1617131133,
+    "wof:lastmodified":1695878940,
     "wof:name":"Rangiora",
     "wof:parent_id":102079367,
     "wof:placetype":"localadmin",

--- a/data/172/923/855/1/1729238551.geojson
+++ b/data/172/923/855/1/1729238551.geojson
@@ -5,11 +5,17 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.003186,
-    "geom:area_square_m":27189988.853897,
+    "geom:area_square_m":27189988.853771,
     "geom:bbox":"167.942618,-46.385443,168.058724,-46.322813",
     "geom:latitude":-46.355867,
     "geom:longitude":167.998272,
     "iso:country":"NZ",
+    "label:eng_x_preferred_placetype":[
+        "territorial authority district"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "autorit\u00e9 territoriale"
+    ],
     "lbl:latitude":-46.362866,
     "lbl:longitude":167.99344,
     "lbl:max_zoom":13.0,
@@ -40,7 +46,7 @@
     ],
     "wof:country":"NZ",
     "wof:created":1600724657,
-    "wof:geomhash":"10341f4662044436c2cc461e841b50a4",
+    "wof:geomhash":"1375fa756372c7b3043dc5412d48f811",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -59,7 +65,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1636495092,
+    "wof:lastmodified":1695878956,
     "wof:name":"Riverton",
     "wof:parent_id":102079391,
     "wof:placetype":"localadmin",

--- a/data/172/923/855/5/1729238555.geojson
+++ b/data/172/923/855/5/1729238555.geojson
@@ -5,11 +5,17 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.002394,
-    "geom:area_square_m":23757736.587849,
+    "geom:area_square_m":23757736.587922,
     "geom:bbox":"174.710765,-36.647922,174.841023,-36.592554",
     "geom:latitude":-36.619267,
     "geom:longitude":174.776634,
     "iso:country":"NZ",
+    "label:eng_x_preferred_placetype":[
+        "territorial authority district"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "autorit\u00e9 territoriale"
+    ],
     "lbl:latitude":-36.614972,
     "lbl:longitude":174.792851,
     "lbl:max_zoom":13.0,
@@ -34,7 +40,7 @@
     "wof:breaches":[],
     "wof:country":"NZ",
     "wof:created":1600724658,
-    "wof:geomhash":"c8cb34e252836582dd42b04e46b7fad2",
+    "wof:geomhash":"00b2abee84c8a6b1e577099cc4363fc4",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -53,7 +59,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1617131487,
+    "wof:lastmodified":1695878943,
     "wof:name":"Whangaparaoa",
     "wof:parent_id":102079403,
     "wof:placetype":"localadmin",

--- a/data/172/923/855/7/1729238557.geojson
+++ b/data/172/923/855/7/1729238557.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.023731,
-    "geom:area_square_m":230790146.974093,
+    "geom:area_square_m":230790146.974063,
     "geom:bbox":"176.166819,-38.241643,176.421112,-38.025921",
     "geom:latitude":-38.138657,
     "geom:longitude":176.299835,
@@ -37,7 +37,7 @@
     ],
     "wof:country":"NZ",
     "wof:created":1600724659,
-    "wof:geomhash":"cc57c9c018a079c4c2681220976b5d0b",
+    "wof:geomhash":"c664ae29b9977a8fc15eb456c585347f",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -56,7 +56,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1617129868,
+    "wof:lastmodified":1695878934,
     "wof:name":"Rotorua",
     "wof:parent_id":102079289,
     "wof:placetype":"localadmin",

--- a/data/172/923/855/7/1729238557.geojson
+++ b/data/172/923/855/7/1729238557.geojson
@@ -10,6 +10,12 @@
     "geom:latitude":-38.138657,
     "geom:longitude":176.299835,
     "iso:country":"NZ",
+    "label:eng_x_preferred_placetype":[
+        "territorial authority district"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "autorit\u00e9 territoriale"
+    ],
     "lbl:latitude":-38.174612,
     "lbl:longitude":176.28861,
     "lbl:max_zoom":13.0,
@@ -56,7 +62,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1695878934,
+    "wof:lastmodified":1696022877,
     "wof:name":"Rotorua",
     "wof:parent_id":102079289,
     "wof:placetype":"localadmin",

--- a/data/172/923/855/9/1729238559.geojson
+++ b/data/172/923/855/9/1729238559.geojson
@@ -5,11 +5,17 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.004471,
-    "geom:area_square_m":45128214.112642,
+    "geom:area_square_m":45128214.11252,
     "geom:bbox":"174.111917,-35.312277,174.261016,-35.241466",
     "geom:latitude":-35.285392,
     "geom:longitude":174.182904,
     "iso:country":"NZ",
+    "label:eng_x_preferred_placetype":[
+        "territorial authority district"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "autorit\u00e9 territoriale"
+    ],
     "lbl:latitude":-35.290041,
     "lbl:longitude":174.181799,
     "lbl:max_zoom":13.0,
@@ -37,7 +43,7 @@
     ],
     "wof:country":"NZ",
     "wof:created":1600724661,
-    "wof:geomhash":"dc17873994042a8d7ba9434cdc1be762",
+    "wof:geomhash":"aef222d1113d30972473ce32d8e92dfd",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -56,7 +62,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1617130928,
+    "wof:lastmodified":1695878939,
     "wof:name":"Russell",
     "wof:parent_id":102079255,
     "wof:placetype":"localadmin",

--- a/data/172/923/856/1/1729238561.geojson
+++ b/data/172/923/856/1/1729238561.geojson
@@ -5,11 +5,17 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.003934,
-    "geom:area_square_m":36542087.101004,
+    "geom:area_square_m":36542087.101091,
     "geom:bbox":"173.975338,-41.340564,174.065551,-41.250402",
     "geom:latitude":-41.29874,
     "geom:longitude":174.024944,
     "iso:country":"NZ",
+    "label:eng_x_preferred_placetype":[
+        "territorial authority district"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "autorit\u00e9 territoriale"
+    ],
     "lbl:latitude":-41.308816,
     "lbl:longitude":174.021928,
     "lbl:max_zoom":13.0,
@@ -73,7 +79,7 @@
     ],
     "wof:country":"NZ",
     "wof:created":1600724661,
-    "wof:geomhash":"a2cfbecf4db14a4f43d491f548ed3862",
+    "wof:geomhash":"40f15efc45f2bc1ac484e9bf1d7487fa",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -92,7 +98,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1636495083,
+    "wof:lastmodified":1695878947,
     "wof:name":"Picton",
     "wof:parent_id":102079353,
     "wof:placetype":"localadmin",

--- a/data/172/923/856/5/1729238565.geojson
+++ b/data/172/923/856/5/1729238565.geojson
@@ -10,6 +10,12 @@
     "geom:latitude":-45.030407,
     "geom:longitude":168.70338,
     "iso:country":"NZ",
+    "label:eng_x_preferred_placetype":[
+        "territorial authority district"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "autorit\u00e9 territoriale"
+    ],
     "lbl:latitude":-45.040575,
     "lbl:longitude":168.722139,
     "lbl:max_zoom":13.0,
@@ -101,7 +107,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1695878947,
+    "wof:lastmodified":1696022880,
     "wof:name":"Queenstown",
     "wof:parent_id":102079385,
     "wof:placetype":"localadmin",

--- a/data/172/923/856/5/1729238565.geojson
+++ b/data/172/923/856/5/1729238565.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.002761,
-    "geom:area_square_m":24129775.120705,
+    "geom:area_square_m":24129775.120756,
     "geom:bbox":"168.621001,-45.051808,168.762677,-44.99713",
     "geom:latitude":-45.030407,
     "geom:longitude":168.70338,
@@ -82,7 +82,7 @@
     ],
     "wof:country":"NZ",
     "wof:created":1600724663,
-    "wof:geomhash":"8fa19d108a00276eb0143f4da6bccd5f",
+    "wof:geomhash":"531e3b55c75d5b07bf20efaaa7e40630",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -101,7 +101,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1636495084,
+    "wof:lastmodified":1695878947,
     "wof:name":"Queenstown",
     "wof:parent_id":102079385,
     "wof:placetype":"localadmin",

--- a/data/172/923/856/7/1729238567.geojson
+++ b/data/172/923/856/7/1729238567.geojson
@@ -5,11 +5,17 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.041285,
-    "geom:area_square_m":394315532.92047,
+    "geom:area_square_m":394315532.92056,
     "geom:bbox":"175.049056,-39.553105,175.34989,-39.307325",
     "geom:latitude":-39.429316,
     "geom:longitude":175.196972,
     "iso:country":"NZ",
+    "label:eng_x_preferred_placetype":[
+        "territorial authority district"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "autorit\u00e9 territoriale"
+    ],
     "lbl:latitude":-39.443838,
     "lbl:longitude":175.221924,
     "lbl:max_zoom":13.0,
@@ -37,7 +43,7 @@
     ],
     "wof:country":"NZ",
     "wof:created":1600724664,
-    "wof:geomhash":"20deedccc27b24c2752810e71f45a901",
+    "wof:geomhash":"54682df1e2414c59ece1e386e99fb2e8",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -56,7 +62,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1603140495,
+    "wof:lastmodified":1695878921,
     "wof:name":"Raetihi",
     "wof:parent_id":102079297,
     "wof:placetype":"localadmin",

--- a/data/172/923/856/9/1729238569.geojson
+++ b/data/172/923/856/9/1729238569.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.006589,
-    "geom:area_square_m":61719031.678057,
+    "geom:area_square_m":61719031.678016,
     "geom:bbox":"175.100717,-40.815354,175.219222,-40.702031",
     "geom:latitude":-40.754056,
     "geom:longitude":175.162756,
@@ -37,7 +37,7 @@
     ],
     "wof:country":"NZ",
     "wof:created":1600724665,
-    "wof:geomhash":"ee8664689327d37e742a3be877857d9b",
+    "wof:geomhash":"bb64ce30ebf20bee50c617a7ceb670eb",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -56,7 +56,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1603140498,
+    "wof:lastmodified":1695878922,
     "wof:name":"Otaki",
     "wof:parent_id":102079315,
     "wof:placetype":"localadmin",

--- a/data/172/923/856/9/1729238569.geojson
+++ b/data/172/923/856/9/1729238569.geojson
@@ -10,6 +10,12 @@
     "geom:latitude":-40.754056,
     "geom:longitude":175.162756,
     "iso:country":"NZ",
+    "label:eng_x_preferred_placetype":[
+        "territorial authority district"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "autorit\u00e9 territoriale"
+    ],
     "lbl:latitude":-40.754781,
     "lbl:longitude":175.167648,
     "lbl:max_zoom":13.0,
@@ -56,7 +62,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1695878922,
+    "wof:lastmodified":1696022867,
     "wof:name":"Otaki",
     "wof:parent_id":102079315,
     "wof:placetype":"localadmin",

--- a/data/172/923/857/3/1729238573.geojson
+++ b/data/172/923/857/3/1729238573.geojson
@@ -5,11 +5,17 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.072302,
-    "geom:area_square_m":679956804.331359,
+    "geom:area_square_m":679956804.330932,
     "geom:bbox":"175.647302,-40.613759,176.166527,-40.370281",
     "geom:latitude":-40.486553,
     "geom:longitude":175.907995,
     "iso:country":"NZ",
+    "label:eng_x_preferred_placetype":[
+        "territorial authority district"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "autorit\u00e9 territoriale"
+    ],
     "lbl:latitude":-40.490366,
     "lbl:longitude":175.907966,
     "lbl:max_zoom":13.0,
@@ -37,7 +43,7 @@
     ],
     "wof:country":"NZ",
     "wof:created":1600724666,
-    "wof:geomhash":"faaa534790dd22e9f33782d5b58b54c5",
+    "wof:geomhash":"b1df32c9b10ff13bb76f5a4d1d04b80f",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -56,7 +62,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1603140503,
+    "wof:lastmodified":1695878922,
     "wof:name":"Pahiatua",
     "wof:parent_id":102079309,
     "wof:placetype":"localadmin",

--- a/data/172/923/857/5/1729238575.geojson
+++ b/data/172/923/857/5/1729238575.geojson
@@ -5,11 +5,17 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.021352,
-    "geom:area_square_m":201063167.327503,
+    "geom:area_square_m":201063167.327438,
     "geom:bbox":"175.498545,-40.52969,175.715549,-40.288726",
     "geom:latitude":-40.401236,
     "geom:longitude":175.604026,
     "iso:country":"NZ",
+    "label:eng_x_preferred_placetype":[
+        "territorial authority district"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "autorit\u00e9 territoriale"
+    ],
     "lbl:latitude":-40.440286,
     "lbl:longitude":175.587559,
     "lbl:max_zoom":13.0,
@@ -40,7 +46,7 @@
     ],
     "wof:country":"NZ",
     "wof:created":1600724667,
-    "wof:geomhash":"6e9ab9b17570956d8d317d9af35dbccb",
+    "wof:geomhash":"68fd9247a384b36503099e87be1ff174",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -59,7 +65,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1636495081,
+    "wof:lastmodified":1695878946,
     "wof:name":"Palmerston North",
     "wof:parent_id":102079307,
     "wof:placetype":"localadmin",

--- a/data/172/923/857/7/1729238577.geojson
+++ b/data/172/923/857/7/1729238577.geojson
@@ -5,11 +5,17 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.003322,
-    "geom:area_square_m":32771092.765452,
+    "geom:area_square_m":32771092.765464,
     "geom:bbox":"174.920381,-37.105936,175.009329,-37.041803",
     "geom:latitude":-37.071555,
     "geom:longitude":174.965278,
     "iso:country":"NZ",
+    "label:eng_x_preferred_placetype":[
+        "territorial authority district"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "autorit\u00e9 territoriale"
+    ],
     "lbl:latitude":-37.064812,
     "lbl:longitude":174.957167,
     "lbl:max_zoom":13.0,
@@ -37,7 +43,7 @@
     ],
     "wof:country":"NZ",
     "wof:created":1600724668,
-    "wof:geomhash":"8aebfd87e7af15eccd8eae9a015e30ee",
+    "wof:geomhash":"53e633afae6ca87e77744753495b5ff5",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -56,7 +62,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1617130274,
+    "wof:lastmodified":1695878937,
     "wof:name":"Papakura",
     "wof:parent_id":102079403,
     "wof:placetype":"localadmin",

--- a/data/172/923/857/9/1729238579.geojson
+++ b/data/172/923/857/9/1729238579.geojson
@@ -5,11 +5,17 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.010012,
-    "geom:area_square_m":92863928.967765,
+    "geom:area_square_m":92863928.967793,
     "geom:bbox":"172.938551,-41.484123,173.098661,-41.33138",
     "geom:latitude":-41.40014,
     "geom:longitude":173.029702,
     "iso:country":"NZ",
+    "label:eng_x_preferred_placetype":[
+        "territorial authority district"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "autorit\u00e9 territoriale"
+    ],
     "lbl:latitude":-41.410722,
     "lbl:longitude":173.050924,
     "lbl:max_zoom":13.0,
@@ -52,7 +58,7 @@
     ],
     "wof:country":"NZ",
     "wof:created":1600724669,
-    "wof:geomhash":"3992af94c3465242b70be722b1a51302",
+    "wof:geomhash":"a54827723d2d14b8e30516c76e503e66",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -71,7 +77,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1636495081,
+    "wof:lastmodified":1695878946,
     "wof:name":"Wakefield",
     "wof:parent_id":102079349,
     "wof:placetype":"localadmin",

--- a/data/172/923/858/1/1729238581.geojson
+++ b/data/172/923/858/1/1729238581.geojson
@@ -5,11 +5,17 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.022886,
-    "geom:area_square_m":217080596.230318,
+    "geom:area_square_m":217080596.229959,
     "geom:bbox":"174.924605,-39.97387,175.266131,-39.803635",
     "geom:latitude":-39.906968,
     "geom:longitude":175.089371,
     "iso:country":"NZ",
+    "label:eng_x_preferred_placetype":[
+        "territorial authority district"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "autorit\u00e9 territoriale"
+    ],
     "lbl:latitude":-39.91351,
     "lbl:longitude":175.086709,
     "lbl:max_zoom":13.0,
@@ -67,7 +73,7 @@
     ],
     "wof:country":"NZ",
     "wof:created":1600724670,
-    "wof:geomhash":"75e0e719b9feb5231c7abfa6787fa756",
+    "wof:geomhash":"7029a0687573c22f00e10e0a0f82e30b",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -86,7 +92,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1636495086,
+    "wof:lastmodified":1695878951,
     "wof:name":"Whanganui",
     "wof:parent_id":102079299,
     "wof:placetype":"localadmin",

--- a/data/172/923/858/3/1729238583.geojson
+++ b/data/172/923/858/3/1729238583.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.030927,
-    "geom:area_square_m":287484267.811532,
+    "geom:area_square_m":287484267.811916,
     "geom:bbox":"174.613106,-41.36238,174.895409,-41.14354",
     "geom:latitude":-41.256608,
     "geom:longitude":174.750133,
@@ -583,7 +583,7 @@
     ],
     "wof:country":"NZ",
     "wof:created":1600724671,
-    "wof:geomhash":"0478f13b033b86f4cae8b969256ce603",
+    "wof:geomhash":"90716f4072c70b1f138ab8ea59b0c04e",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -602,7 +602,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1690849959,
+    "wof:lastmodified":1695878937,
     "wof:name":"Wellington",
     "wof:parent_id":102079339,
     "wof:placetype":"localadmin",

--- a/data/172/923/858/3/1729238583.geojson
+++ b/data/172/923/858/3/1729238583.geojson
@@ -11,6 +11,12 @@
     "geom:longitude":174.750133,
     "gn:population":381900,
     "iso:country":"NZ",
+    "label:eng_x_preferred_placetype":[
+        "territorial authority city"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "collectivit\u00e9 territoriale ville"
+    ],
     "lbl:latitude":-41.28566,
     "lbl:longitude":174.724424,
     "lbl:max_zoom":13.0,
@@ -602,7 +608,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1695878937,
+    "wof:lastmodified":1696022877,
     "wof:name":"Wellington",
     "wof:parent_id":102079339,
     "wof:placetype":"localadmin",

--- a/data/172/923/858/5/1729238585.geojson
+++ b/data/172/923/858/5/1729238585.geojson
@@ -5,11 +5,17 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.014448,
-    "geom:area_square_m":133212652.070409,
+    "geom:area_square_m":133212652.07095,
     "geom:bbox":"171.514535,-41.864596,171.702652,-41.727024",
     "geom:latitude":-41.786438,
     "geom:longitude":171.611237,
     "iso:country":"NZ",
+    "label:eng_x_preferred_placetype":[
+        "territorial authority district"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "autorit\u00e9 territoriale"
+    ],
     "lbl:latitude":-41.769927,
     "lbl:longitude":171.617647,
     "lbl:max_zoom":13.0,
@@ -79,7 +85,7 @@
     ],
     "wof:country":"NZ",
     "wof:created":1600724671,
-    "wof:geomhash":"d4c69d43d36cdd130ab3e545412bec2d",
+    "wof:geomhash":"8f82803ad1223e9b1bf1cadd31e06d77",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -98,7 +104,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1636495086,
+    "wof:lastmodified":1695878951,
     "wof:name":"Westport",
     "wof:parent_id":102079357,
     "wof:placetype":"localadmin",

--- a/data/172/923/858/7/1729238587.geojson
+++ b/data/172/923/858/7/1729238587.geojson
@@ -5,11 +5,17 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.002971,
-    "geom:area_square_m":29173600.154754,
+    "geom:area_square_m":29173600.154797,
     "geom:bbox":"175.890842,-37.469016,175.991746,-37.373037",
     "geom:latitude":-37.423507,
     "geom:longitude":175.935445,
     "iso:country":"NZ",
+    "label:eng_x_preferred_placetype":[
+        "territorial authority district"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "autorit\u00e9 territoriale"
+    ],
     "lbl:latitude":-37.41833,
     "lbl:longitude":175.932015,
     "lbl:max_zoom":13.0,
@@ -37,7 +43,7 @@
     ],
     "wof:country":"NZ",
     "wof:created":1600724672,
-    "wof:geomhash":"e64d8d49e18124fd21eb3005c99eb543",
+    "wof:geomhash":"145937796db6ac6a374569caf02eb165",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -56,7 +62,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1617130289,
+    "wof:lastmodified":1695878937,
     "wof:name":"Waihi Beach",
     "wof:parent_id":102079283,
     "wof:placetype":"localadmin",

--- a/data/172/923/859/1/1729238591.geojson
+++ b/data/172/923/859/1/1729238591.geojson
@@ -5,11 +5,17 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.003282,
-    "geom:area_square_m":31321871.841635,
+    "geom:area_square_m":31321871.841583,
     "geom:bbox":"175.627034,-39.527816,175.701656,-39.438387",
     "geom:latitude":-39.491553,
     "geom:longitude":175.660119,
     "iso:country":"NZ",
+    "label:eng_x_preferred_placetype":[
+        "territorial authority district"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "autorit\u00e9 territoriale"
+    ],
     "lbl:latitude":-39.501482,
     "lbl:longitude":175.654464,
     "lbl:max_zoom":13.0,
@@ -37,7 +43,7 @@
     ],
     "wof:country":"NZ",
     "wof:created":1600724673,
-    "wof:geomhash":"d9da51537bcbe99add46326d9c93adc7",
+    "wof:geomhash":"1ea8ad51224609371af42d02bfcae82b",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -56,7 +62,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1603140556,
+    "wof:lastmodified":1695878922,
     "wof:name":"Waiouru",
     "wof:parent_id":102079297,
     "wof:placetype":"localadmin",

--- a/data/172/923/859/3/1729238593.geojson
+++ b/data/172/923/859/3/1729238593.geojson
@@ -5,11 +5,17 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.00352,
-    "geom:area_square_m":31112777.588093,
+    "geom:area_square_m":31112777.587816,
     "geom:bbox":"171.174058,-44.42603,171.272917,-44.331749",
     "geom:latitude":-44.379776,
     "geom:longitude":171.233308,
     "iso:country":"NZ",
+    "label:eng_x_preferred_placetype":[
+        "territorial authority district"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "autorit\u00e9 territoriale"
+    ],
     "lbl:latitude":-44.389786,
     "lbl:longitude":171.233331,
     "lbl:max_zoom":13.0,
@@ -37,7 +43,7 @@
     ],
     "wof:country":"NZ",
     "wof:created":1600724674,
-    "wof:geomhash":"85821c88b1ccebf19279789df95545d5",
+    "wof:geomhash":"99e966c46845d0cb7390fd7c056b80b2",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -56,7 +62,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1617130345,
+    "wof:lastmodified":1695878938,
     "wof:name":"Timaru",
     "wof:parent_id":102079373,
     "wof:placetype":"localadmin",

--- a/data/172/923/859/5/1729238595.geojson
+++ b/data/172/923/859/5/1729238595.geojson
@@ -5,11 +5,17 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.012517,
-    "geom:area_square_m":120263596.394619,
+    "geom:area_square_m":120263596.395544,
     "geom:bbox":"175.772519,-39.093707,175.9417,-38.939168",
     "geom:latitude":-39.010966,
     "geom:longitude":175.858647,
     "iso:country":"NZ",
+    "label:eng_x_preferred_placetype":[
+        "territorial authority district"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "autorit\u00e9 territoriale"
+    ],
     "lbl:latitude":-39.012236,
     "lbl:longitude":175.859935,
     "lbl:max_zoom":13.0,
@@ -94,7 +100,7 @@
     ],
     "wof:country":"NZ",
     "wof:created":1600724675,
-    "wof:geomhash":"94c160a523a7e06ce7ad18e03dbbda89",
+    "wof:geomhash":"2c82bb8831690d7f9ee5beda8fa7bd64",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -113,7 +119,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1636495079,
+    "wof:lastmodified":1695878944,
     "wof:name":"Turangi",
     "wof:parent_id":102079281,
     "wof:placetype":"localadmin",

--- a/data/172/923/859/7/1729238597.geojson
+++ b/data/172/923/859/7/1729238597.geojson
@@ -5,11 +5,17 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.036829,
-    "geom:area_square_m":343362605.694914,
+    "geom:area_square_m":343362605.695404,
     "geom:bbox":"174.991794,-41.226208,175.306299,-40.949343",
     "geom:latitude":-41.063128,
     "geom:longitude":175.138049,
     "iso:country":"NZ",
+    "label:eng_x_preferred_placetype":[
+        "territorial authority district"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "autorit\u00e9 territoriale"
+    ],
     "lbl:latitude":-41.054182,
     "lbl:longitude":175.109446,
     "lbl:max_zoom":13.0,
@@ -40,7 +46,7 @@
     ],
     "wof:country":"NZ",
     "wof:created":1600724676,
-    "wof:geomhash":"1ae645f39fb72d1a8a1f73c830464aa5",
+    "wof:geomhash":"718cf8eba544d841a8e0483354c47362",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -59,7 +65,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1636495079,
+    "wof:lastmodified":1695878944,
     "wof:name":"Upper Hutt",
     "wof:parent_id":102079335,
     "wof:placetype":"localadmin",

--- a/data/172/923/859/9/1729238599.geojson
+++ b/data/172/923/859/9/1729238599.geojson
@@ -5,11 +5,17 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.020845,
-    "geom:area_square_m":204748388.703472,
+    "geom:area_square_m":204748388.703385,
     "geom:bbox":"175.729743,-37.495683,175.944094,-37.315633",
     "geom:latitude":-37.403977,
     "geom:longitude":175.83962,
     "iso:country":"NZ",
+    "label:eng_x_preferred_placetype":[
+        "territorial authority district"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "autorit\u00e9 territoriale"
+    ],
     "lbl:latitude":-37.407069,
     "lbl:longitude":175.846907,
     "lbl:max_zoom":13.0,
@@ -37,7 +43,7 @@
     ],
     "wof:country":"NZ",
     "wof:created":1600724677,
-    "wof:geomhash":"63b7b4179c9de2537257a4e3f9a4af4d",
+    "wof:geomhash":"839f0397839f1b7c3a75c52dcaf714de",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -56,7 +62,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1603140660,
+    "wof:lastmodified":1695878922,
     "wof:name":"Waihi",
     "wof:parent_id":102079263,
     "wof:placetype":"localadmin",

--- a/data/172/923/860/1/1729238601.geojson
+++ b/data/172/923/860/1/1729238601.geojson
@@ -5,11 +5,17 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.022938,
-    "geom:area_square_m":221446977.653864,
+    "geom:area_square_m":221446977.653244,
     "geom:bbox":"175.954476,-38.778402,176.207417,-38.55399",
     "geom:latitude":-38.669322,
     "geom:longitude":176.088041,
     "iso:country":"NZ",
+    "label:eng_x_preferred_placetype":[
+        "territorial authority district"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "autorit\u00e9 territoriale"
+    ],
     "lbl:latitude":-38.602976,
     "lbl:longitude":176.075697,
     "lbl:max_zoom":13.0,
@@ -52,7 +58,7 @@
     ],
     "wof:country":"NZ",
     "wof:created":1600724678,
-    "wof:geomhash":"4be0db4145b9568d8cb479095dfae2c5",
+    "wof:geomhash":"54088f888b53a0197a19a2d665a85359",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -71,7 +77,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1636495084,
+    "wof:lastmodified":1695878948,
     "wof:name":"Taupo",
     "wof:parent_id":102079281,
     "wof:placetype":"localadmin",

--- a/data/172/923/860/3/1729238603.geojson
+++ b/data/172/923/860/3/1729238603.geojson
@@ -10,6 +10,12 @@
     "geom:latitude":-37.739172,
     "geom:longitude":176.142989,
     "iso:country":"NZ",
+    "label:eng_x_preferred_placetype":[
+        "territorial authority city"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "collectivit\u00e9 territoriale ville"
+    ],
     "lbl:latitude":-37.727941,
     "lbl:longitude":176.122552,
     "lbl:max_zoom":13.0,
@@ -59,7 +65,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1695878949,
+    "wof:lastmodified":1696022880,
     "wof:name":"Tauranga",
     "wof:parent_id":102079285,
     "wof:placetype":"localadmin",

--- a/data/172/923/860/3/1729238603.geojson
+++ b/data/172/923/860/3/1729238603.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.011112,
-    "geom:area_square_m":108659808.468151,
+    "geom:area_square_m":108659808.470581,
     "geom:bbox":"176.072354,-37.849791,176.230609,-37.65825",
     "geom:latitude":-37.739172,
     "geom:longitude":176.142989,
@@ -40,7 +40,7 @@
     ],
     "wof:country":"NZ",
     "wof:created":1600724679,
-    "wof:geomhash":"23bfb2b1027304f531cfe63710ce21bc",
+    "wof:geomhash":"bc73e80390a7e807de23d9820b28674b",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -59,7 +59,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1636495085,
+    "wof:lastmodified":1695878949,
     "wof:name":"Tauranga",
     "wof:parent_id":102079285,
     "wof:placetype":"localadmin",

--- a/data/172/923/860/5/1729238605.geojson
+++ b/data/172/923/860/5/1729238605.geojson
@@ -5,11 +5,17 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.015878,
-    "geom:area_square_m":154698993.923849,
+    "geom:area_square_m":154698993.923888,
     "geom:bbox":"175.233159,-38.095504,175.431804,-37.944573",
     "geom:latitude":-38.008216,
     "geom:longitude":175.338349,
     "iso:country":"NZ",
+    "label:eng_x_preferred_placetype":[
+        "territorial authority district"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "autorit\u00e9 territoriale"
+    ],
     "lbl:latitude":-38.006692,
     "lbl:longitude":175.344804,
     "lbl:max_zoom":13.0,
@@ -37,7 +43,7 @@
     ],
     "wof:country":"NZ",
     "wof:created":1600724681,
-    "wof:geomhash":"f6ca6dad2f918ca8f44c0a0679ec1405",
+    "wof:geomhash":"d8ceef9f145a69e068227f8fd7a840a4",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -56,7 +62,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1617131066,
+    "wof:lastmodified":1695878939,
     "wof:name":"Te Awamutu",
     "wof:parent_id":102079273,
     "wof:placetype":"localadmin",

--- a/data/172/923/860/9/1729238609.geojson
+++ b/data/172/923/860/9/1729238609.geojson
@@ -5,11 +5,17 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.001055,
-    "geom:area_square_m":9814050.124261,
+    "geom:area_square_m":9814050.124248,
     "geom:bbox":"173.055294,-41.261386,173.108441,-41.207572",
     "geom:latitude":-41.239055,
     "geom:longitude":173.081925,
     "iso:country":"NZ",
+    "label:eng_x_preferred_placetype":[
+        "territorial authority district"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "autorit\u00e9 territoriale"
+    ],
     "lbl:latitude":-41.244405,
     "lbl:longitude":173.083726,
     "lbl:max_zoom":13.0,
@@ -37,7 +43,7 @@
     ],
     "wof:country":"NZ",
     "wof:created":1600724682,
-    "wof:geomhash":"fb2e7c2523958694e29df3957cbe8aa9",
+    "wof:geomhash":"c6fca9a6be43f79c73c9225323116689",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -56,7 +62,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1617131292,
+    "wof:lastmodified":1695878941,
     "wof:name":"Mapua",
     "wof:parent_id":102079349,
     "wof:placetype":"localadmin",

--- a/data/172/923/861/1/1729238611.geojson
+++ b/data/172/923/861/1/1729238611.geojson
@@ -5,11 +5,17 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.013923,
-    "geom:area_square_m":139986026.903572,
+    "geom:area_square_m":139986026.903151,
     "geom:bbox":"174.228774,-35.662259,174.439033,-35.527616",
     "geom:latitude":-35.598768,
     "geom:longitude":174.347921,
     "iso:country":"NZ",
+    "label:eng_x_preferred_placetype":[
+        "territorial authority district"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "autorit\u00e9 territoriale"
+    ],
     "lbl:latitude":-35.599767,
     "lbl:longitude":174.355126,
     "lbl:max_zoom":13.0,
@@ -37,7 +43,7 @@
     ],
     "wof:country":"NZ",
     "wof:created":1600724683,
-    "wof:geomhash":"d1a29451d28752c4970ba06e16fae6d6",
+    "wof:geomhash":"b7182b41d29d88094ad149295152954b",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -56,7 +62,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1603140796,
+    "wof:lastmodified":1695878922,
     "wof:name":"Hikurangi",
     "wof:parent_id":102079257,
     "wof:placetype":"localadmin",

--- a/data/172/923/861/3/1729238613.geojson
+++ b/data/172/923/861/3/1729238613.geojson
@@ -5,11 +5,17 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.009703,
-    "geom:area_square_m":95476796.833705,
+    "geom:area_square_m":95476796.833604,
     "geom:bbox":"175.420339,-37.324061,175.619377,-37.223647",
     "geom:latitude":-37.27169,
     "geom:longitude":175.517099,
     "iso:country":"NZ",
+    "label:eng_x_preferred_placetype":[
+        "territorial authority district"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "autorit\u00e9 territoriale"
+    ],
     "lbl:latitude":-37.280003,
     "lbl:longitude":175.492339,
     "lbl:max_zoom":13.0,
@@ -37,7 +43,7 @@
     ],
     "wof:country":"NZ",
     "wof:created":1600724684,
-    "wof:geomhash":"969c0143869e85b5d9e7a322ad270aee",
+    "wof:geomhash":"79440a75f0cd2ee4968125a0713ded9c",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -56,7 +62,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1603140814,
+    "wof:lastmodified":1695878922,
     "wof:name":"Ngatea",
     "wof:parent_id":102079263,
     "wof:placetype":"localadmin",

--- a/data/172/923/861/5/1729238615.geojson
+++ b/data/172/923/861/5/1729238615.geojson
@@ -5,11 +5,17 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.008492,
-    "geom:area_square_m":82767871.986538,
+    "geom:area_square_m":82767871.986561,
     "geom:bbox":"176.906839,-38.033935,177.068761,-37.920827",
     "geom:latitude":-37.978505,
     "geom:longitude":176.983066,
     "iso:country":"NZ",
+    "label:eng_x_preferred_placetype":[
+        "territorial authority district"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "autorit\u00e9 territoriale"
+    ],
     "lbl:latitude":-37.979731,
     "lbl:longitude":176.977542,
     "lbl:max_zoom":13.0,
@@ -100,7 +106,7 @@
     ],
     "wof:country":"NZ",
     "wof:created":1600724684,
-    "wof:geomhash":"648f7e88a8be7d8a34369edce2fdf894",
+    "wof:geomhash":"936072f798c5da7ec2cc7d1e7281fc92",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -119,7 +125,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1636495080,
+    "wof:lastmodified":1695878944,
     "wof:name":"Whakatane",
     "wof:parent_id":102079291,
     "wof:placetype":"localadmin",

--- a/data/172/923/861/7/1729238617.geojson
+++ b/data/172/923/861/7/1729238617.geojson
@@ -10,6 +10,12 @@
     "geom:latitude":-35.80863,
     "geom:longitude":174.314609,
     "iso:country":"NZ",
+    "label:eng_x_preferred_placetype":[
+        "territorial authority district"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "autorit\u00e9 territoriale"
+    ],
     "lbl:latitude":-35.880069,
     "lbl:longitude":174.311341,
     "lbl:max_zoom":13.0,
@@ -62,7 +68,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1695878945,
+    "wof:lastmodified":1696022879,
     "wof:name":"Whangarei",
     "wof:parent_id":102079257,
     "wof:placetype":"localadmin",

--- a/data/172/923/861/7/1729238617.geojson
+++ b/data/172/923/861/7/1729238617.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.032977,
-    "geom:area_square_m":330690041.746431,
+    "geom:area_square_m":330690041.74614,
     "geom:bbox":"174.122349,-35.947352,174.501258,-35.647942",
     "geom:latitude":-35.80863,
     "geom:longitude":174.314609,
@@ -43,7 +43,7 @@
     ],
     "wof:country":"NZ",
     "wof:created":1600724685,
-    "wof:geomhash":"750751705732726b1212c196b5f5f810",
+    "wof:geomhash":"92c0f26c3f5dd0bc5c444feffa9ae33b",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -62,7 +62,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1636495080,
+    "wof:lastmodified":1695878945,
     "wof:name":"Whangarei",
     "wof:parent_id":102079257,
     "wof:placetype":"localadmin",

--- a/data/172/923/861/9/1729238619.geojson
+++ b/data/172/923/861/9/1729238619.geojson
@@ -5,11 +5,17 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.002012,
-    "geom:area_square_m":18093833.113063,
+    "geom:area_square_m":18093833.113145,
     "geom:bbox":"172.646423,-43.353051,172.713641,-43.297685",
     "geom:latitude":-43.329589,
     "geom:longitude":172.680701,
     "iso:country":"NZ",
+    "label:eng_x_preferred_placetype":[
+        "territorial authority district"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "autorit\u00e9 territoriale"
+    ],
     "lbl:latitude":-43.334266,
     "lbl:longitude":172.682974,
     "lbl:max_zoom":13.0,
@@ -37,7 +43,7 @@
     ],
     "wof:country":"NZ",
     "wof:created":1600724686,
-    "wof:geomhash":"323eee88916431b73323ee9ca9075b3e",
+    "wof:geomhash":"5d94fc60074bf218ec19bbf1feecde43",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -56,7 +62,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1617131214,
+    "wof:lastmodified":1695878941,
     "wof:name":"Woodend",
     "wof:parent_id":102079367,
     "wof:placetype":"localadmin",

--- a/data/856/324/81/85632481.geojson
+++ b/data/856/324/81/85632481.geojson
@@ -897,6 +897,7 @@
         "gp:id":23424795,
         "hasc:id":"CK.CK",
         "ioc:id":"COK",
+        "iso:code":"CK",
         "iso:id":"CK-CK",
         "itu:id":"CKH",
         "m49:code":"184",
@@ -908,6 +909,7 @@
         "wd:id":"Q26988",
         "wmo:id":"KU"
     },
+    "wof:concordances_official":"iso:code",
     "wof:controlled":[
         "wof:hierarchy",
         "wof:parent_id"
@@ -933,7 +935,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1694639809,
+    "wof:lastmodified":1695881381,
     "wof:name":"Cook Islands",
     "wof:parent_id":136253053,
     "wof:placetype":"dependency",

--- a/data/856/324/93/85632493.geojson
+++ b/data/856/324/93/85632493.geojson
@@ -880,6 +880,7 @@
         "gp:id":23424904,
         "hasc:id":"NU",
         "ioc:id":"NIU",
+        "iso:code":"NU",
         "itu:id":"NIU",
         "m49:code":"570",
         "marc:id":"xh",
@@ -892,6 +893,7 @@
     "wof:concordances_alt":{
         "qs_pg:id":897038
     },
+    "wof:concordances_official":"iso:code",
     "wof:controlled":[
         "wof:hierarchy",
         "wof:parent_id"
@@ -917,7 +919,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1694639813,
+    "wof:lastmodified":1695881384,
     "wof:name":"Niue",
     "wof:parent_id":136253053,
     "wof:placetype":"dependency",

--- a/data/856/333/45/85633345.geojson
+++ b/data/856/333/45/85633345.geojson
@@ -1203,6 +1203,7 @@
         "hasc:id":"NZ",
         "icao:code":"ZK",
         "ioc:id":"NZL",
+        "iso:code":"NZ",
         "itu:id":"NZL",
         "loc:id":"n79021322",
         "m49:code":"554",
@@ -1215,6 +1216,7 @@
         "wd:id":"Q664",
         "wmo:id":"NZ"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"NZ",
     "wof:country_alpha3":"NZL",
     "wof:geom_alt":[
@@ -1237,7 +1239,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1694639504,
+    "wof:lastmodified":1695881159,
     "wof:name":"New Zealand",
     "wof:parent_id":102191583,
     "wof:placetype":"country",

--- a/data/856/871/49/85687149.geojson
+++ b/data/856/871/49/85687149.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.984759,
-    "geom:area_square_m":30104481092.623817,
+    "geom:area_square_m":30104481092.623322,
     "geom:bbox":"172.392389,-36.558506,174.993537,-34.193512",
     "geom:latitude":-35.341423,
     "geom:longitude":173.740876,
@@ -312,12 +312,18 @@
         "gn:id":2185978,
         "gp:id":15021755,
         "hasc:id":"NZ.NO",
+        "iso:code":"NZ-NTL",
         "iso:id":"NZ-NTL",
+        "nz-linz:id":"01",
         "unlc:id":"NZ-NTL",
         "wd:id":"Q59596"
     },
+    "wof:concordances_official":"nz-linz:id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"NZ",
-    "wof:geomhash":"9daa1be64d5a021bc1787e7c9744f933",
+    "wof:geomhash":"65348483e6f251995a7036029695893c",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -334,7 +340,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1690849942,
+    "wof:lastmodified":1695884452,
     "wof:name":"Northland Region",
     "wof:parent_id":85633345,
     "wof:placetype":"region",

--- a/data/856/871/57/85687157.geojson
+++ b/data/856/871/57/85687157.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.132509,
-    "geom:area_square_m":1234581819.371246,
+    "geom:area_square_m":1234581819.371124,
     "geom:bbox":"173.176422,-41.393428,173.598762,-40.805375",
     "geom:latitude":-41.113609,
     "geom:longitude":173.396306,
@@ -93,10 +93,16 @@
         "digitalenvoy:region_code":25048,
         "fips:code":"NZF5",
         "hasc:id":"NZ.NE",
-        "iso:id":"NZ-NSN"
+        "iso:code":"NZ-NSN",
+        "iso:id":"NZ-NSN",
+        "nz-linz:id":"17"
     },
+    "wof:concordances_official":"nz-linz:id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"NZ",
-    "wof:geomhash":"a861ed0470b3bef32140495330c62c1f",
+    "wof:geomhash":"5ad557059bec960b53d9c19a639bff86",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -113,7 +119,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1607462729,
+    "wof:lastmodified":1695884452,
     "wof:name":"Nelson Region",
     "wof:parent_id":85633345,
     "wof:placetype":"region",

--- a/data/856/871/61/85687161.geojson
+++ b/data/856/871/61/85687161.geojson
@@ -46,7 +46,10 @@
         85633345
     ],
     "wof:breaches":[],
-    "wof:concordances":{},
+    "wof:concordances":{
+        "nz-linz:id":"99"
+    },
+    "wof:concordances_official":"nz-linz:id",
     "wof:country":"NZ",
     "wof:geomhash":"299c123a1093214a5f756868b992a639",
     "wof:hierarchy":[
@@ -65,7 +68,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1694498185,
+    "wof:lastmodified":1695884756,
     "wof:name":"Area Outside Region",
     "wof:parent_id":85633345,
     "wof:placetype":"region",

--- a/data/856/871/65/85687165.geojson
+++ b/data/856/871/65/85687165.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":3.994887,
-    "geom:area_square_m":36269757740.625107,
+    "geom:area_square_m":36269757740.664406,
     "geom:bbox":"167.838118,-44.499066,172.692102,-40.628352",
     "geom:latitude":-42.748091,
     "geom:longitude":170.69102,
@@ -250,12 +250,18 @@
         "digitalenvoy:region_code":25056,
         "fips:code":"NZG3",
         "hasc:id":"NZ.WC",
+        "iso:code":"NZ-WTC",
         "iso:id":"NZ-WTC",
+        "nz-linz:id":"12",
         "unlc:id":"NZ-WTC",
         "wd:id":"Q541468"
     },
+    "wof:concordances_official":"nz-linz:id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"NZ",
-    "wof:geomhash":"8b8a1ead3eade32098b31c9faa40fcbc",
+    "wof:geomhash":"1c919e9a4f0469445e99317c0143d6a3",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -272,7 +278,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1690849939,
+    "wof:lastmodified":1695884452,
     "wof:name":"West Coast Region",
     "wof:parent_id":85633345,
     "wof:placetype":"region",

--- a/data/856/871/75/85687175.geojson
+++ b/data/856/871/75/85687175.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.236987,
-    "geom:area_square_m":21827242248.491798,
+    "geom:area_square_m":21827242248.486778,
     "geom:bbox":"175.805921,-39.005085,178.107555,-36.893635",
     "geom:latitude":-37.897231,
     "geom:longitude":176.863033,
@@ -258,12 +258,18 @@
         "digitalenvoy:region_code":25042,
         "fips:code":"NZE8",
         "hasc:id":"NZ.BP",
+        "iso:code":"NZ-BOP",
         "iso:id":"NZ-BOP",
+        "nz-linz:id":"04",
         "unlc:id":"NZ-BOP",
         "wd:id":"Q2192924"
     },
+    "wof:concordances_official":"nz-linz:id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"NZ",
-    "wof:geomhash":"f478a80dbd72cd8e4fd420b37fab6580",
+    "wof:geomhash":"c1fa8ba389703cfc418a5abdb5461a0c",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -280,7 +286,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1690849938,
+    "wof:lastmodified":1695884454,
     "wof:name":"Bay of Plenty Region",
     "wof:parent_id":85633345,
     "wof:placetype":"region",

--- a/data/856/871/79/85687179.geojson
+++ b/data/856/871/79/85687179.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":6.328785,
-    "geom:area_square_m":56691719275.67556,
+    "geom:area_square_m":56691719275.658798,
     "geom:bbox":"169.542498,-45.080929,174.264103,-41.907383",
     "geom:latitude":-43.573456,
     "geom:longitude":171.797241,
@@ -352,12 +352,18 @@
         "gn:id":2192628,
         "gp:id":15021751,
         "hasc:id":"NZ.CA",
+        "iso:code":"NZ-CAN",
         "iso:id":"NZ-CAN",
+        "nz-linz:id":"13",
         "unlc:id":"NZ-CAN",
         "wd:id":"Q657004"
     },
+    "wof:concordances_official":"nz-linz:id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"NZ",
-    "wof:geomhash":"d6fa7217209fae60f68593545470d245",
+    "wof:geomhash":"390d2af1ea8dd862eb2d2b9c33532752",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -374,7 +380,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1690849940,
+    "wof:lastmodified":1695884455,
     "wof:name":"Canterbury Region",
     "wof:parent_id":85633345,
     "wof:placetype":"region",

--- a/data/856/871/85/85687185.geojson
+++ b/data/856/871/85/85687185.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.907841,
-    "geom:area_square_m":17676466006.639938,
+    "geom:area_square_m":17676466006.647339,
     "geom:bbox":"172.71853,-42.488129,174.603476,-40.460762",
     "geom:latitude":-41.467899,
     "geom:longitude":173.775769,
@@ -303,11 +303,17 @@
         "gn:id":2187304,
         "gp:id":15021759,
         "hasc:id":"NZ.MA",
+        "iso:code":"NZ-MBH",
         "iso:id":"NZ-MBH",
+        "nz-linz:id":"18",
         "wd:id":"Q140083"
     },
+    "wof:concordances_official":"nz-linz:id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"NZ",
-    "wof:geomhash":"99eb0355d548c3ab99d21550b2408b86",
+    "wof:geomhash":"5852cd259b62551ba4708c9bec15816e",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -324,7 +330,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1690849941,
+    "wof:lastmodified":1695884456,
     "wof:name":"Marlborough Region",
     "wof:parent_id":85633345,
     "wof:placetype":"region",

--- a/data/856/871/89/85687189.geojson
+++ b/data/856/871/89/85687189.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.239036,
-    "geom:area_square_m":21380662793.444153,
+    "geom:area_square_m":21380662793.440308,
     "geom:bbox":"176.042936,-40.493139,178.263069,-38.583921",
     "geom:latitude":-39.441351,
     "geom:longitude":176.963822,
@@ -245,11 +245,17 @@
         "digitalenvoy:region_code":25045,
         "fips:code":"NZF2",
         "hasc:id":"NZ.HB",
+        "iso:code":"NZ-HKB",
         "iso:id":"NZ-HKB",
+        "nz-linz:id":"06",
         "wd:id":"Q251825"
     },
+    "wof:concordances_official":"nz-linz:id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"NZ",
-    "wof:geomhash":"7aa4c580b3abf9890e462c253ed6b09c",
+    "wof:geomhash":"ccd2a8667c8d29178ba24c4d933547bd",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -266,7 +272,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1690849937,
+    "wof:lastmodified":1695884457,
     "wof:name":"Hawke's Bay Region",
     "wof:parent_id":85633345,
     "wof:placetype":"region",

--- a/data/856/871/95/85687195.geojson
+++ b/data/856/871/95/85687195.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.32736,
-    "geom:area_square_m":12692414611.450315,
+    "geom:area_square_m":12692414611.449135,
     "geom:bbox":"173.492567,-40.068959,174.991765,-38.701748",
     "geom:latitude":-39.346502,
     "geom:longitude":174.278618,
@@ -296,12 +296,18 @@
         "gn:id":2181872,
         "gp:id":15021763,
         "hasc:id":"NZ.TK",
+        "iso:code":"NZ-TKI",
         "iso:id":"NZ-TKI",
+        "nz-linz:id":"07",
         "unlc:id":"NZ-TKI",
         "wd:id":"Q140207"
     },
+    "wof:concordances_official":"nz-linz:id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"NZ",
-    "wof:geomhash":"ef2d3979aafe6911fa55f997ae940d5e",
+    "wof:geomhash":"7861622f042439c5cee3bc1ef5b7b7e0",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -318,7 +324,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1690849936,
+    "wof:lastmodified":1695884458,
     "wof:name":"Taranaki Region",
     "wof:parent_id":85633345,
     "wof:placetype":"region",

--- a/data/856/872/01/85687201.geojson
+++ b/data/856/872/01/85687201.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":4.421057,
-    "geom:area_square_m":38392140674.45594,
+    "geom:area_square_m":38392140674.463341,
     "geom:bbox":"168.116395,-46.839379,171.406801,-43.955411",
     "geom:latitude":-45.385754,
     "geom:longitude":169.696786,
@@ -299,12 +299,18 @@
         "gn:id":6612109,
         "gp:id":15021754,
         "hasc:id":"NZ.OT",
+        "iso:code":"NZ-OTA",
         "iso:id":"NZ-OTA",
+        "nz-linz:id":"14",
         "unlc:id":"NZ-OTA",
         "wd:id":"Q692912"
     },
+    "wof:concordances_official":"nz-linz:id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"NZ",
-    "wof:geomhash":"bb68e3ad1df7f42402e0cf263a2be98e",
+    "wof:geomhash":"d1a504a7a384c0658177bc6c222da93d",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -321,7 +327,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1690849931,
+    "wof:lastmodified":1695884458,
     "wof:name":"Otago Region",
     "wof:parent_id":85633345,
     "wof:placetype":"region",

--- a/data/856/872/11/85687211.geojson
+++ b/data/856/872/11/85687211.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":6.393621,
-    "geom:area_square_m":54922446481.596794,
+    "geom:area_square_m":54922446481.600151,
     "geom:bbox":"166.138653,-47.724046,169.342055,-44.127058",
     "geom:latitude":-45.99093,
     "geom:longitude":167.746888,
@@ -303,12 +303,18 @@
         "gn:id":2182501,
         "gp:id":15021750,
         "hasc:id":"NZ.SO",
+        "iso:code":"NZ-STL",
         "iso:id":"NZ-STL",
+        "nz-linz:id":"15",
         "unlc:id":"NZ-STL",
         "wd:id":"Q864971"
     },
+    "wof:concordances_official":"nz-linz:id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"NZ",
-    "wof:geomhash":"42fecfa7e5d6f2b63119257c935d7740",
+    "wof:geomhash":"c9ded821ab219fc54b2d2d739a8ca47c",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -325,7 +331,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1690849929,
+    "wof:lastmodified":1695884459,
     "wof:name":"Southland Region",
     "wof:parent_id":85633345,
     "wof:placetype":"region",

--- a/data/856/872/15/85687215.geojson
+++ b/data/856/872/15/85687215.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.49764,
-    "geom:area_square_m":13324495430.643661,
+    "geom:area_square_m":13324495430.643631,
     "geom:bbox":"-177.357902,-44.608488,-175.500024,-43.346533",
     "geom:latitude":-43.984416,
     "geom:longitude":-176.416182,
@@ -379,11 +379,17 @@
         "gn:id":4033013,
         "gp:id":56126020,
         "hasc:id":"NZ.CI",
+        "iso:code":"NZ-CIT",
         "iso:id":"NZ-CIT",
+        "nz-linz:id":"99",
         "wd:id":"Q115459"
     },
+    "wof:concordances_official":"nz-linz:id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"NZ",
-    "wof:geomhash":"a2879efc6d841c89bc467f2586d7c16c",
+    "wof:geomhash":"6e261a6142cf315094b92bb4b6c25117",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -400,7 +406,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1690849932,
+    "wof:lastmodified":1695884442,
     "wof:name":"Chatham Islands",
     "wof:parent_id":85633345,
     "wof:placetype":"region",

--- a/data/856/872/19/85687219.geojson
+++ b/data/856/872/19/85687219.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.58945,
-    "geom:area_square_m":14792581564.873327,
+    "geom:area_square_m":14792581564.87323,
     "geom:bbox":"172.030696,-42.305574,173.361031,-40.298213",
     "geom:latitude":-41.175678,
     "geom:longitude":172.725438,
@@ -132,10 +132,16 @@
         "gn:id":2181818,
         "gp:id":15021757,
         "hasc:id":"NZ.TS",
-        "iso:id":"NZ-TAS"
+        "iso:code":"NZ-TAS",
+        "iso:id":"NZ-TAS",
+        "nz-linz:id":"16"
     },
+    "wof:concordances_official":"nz-linz:id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"NZ",
-    "wof:geomhash":"250c139dc76a6bf4b3ee47e982a1c7ef",
+    "wof:geomhash":"2be2ea2a0df34e118ac52789824254a2",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -152,7 +158,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1607462736,
+    "wof:lastmodified":1695884460,
     "wof:name":"Tasman Region",
     "wof:parent_id":85633345,
     "wof:placetype":"region",

--- a/data/856/872/29/85687229.geojson
+++ b/data/856/872/29/85687229.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":3.568812,
-    "geom:area_square_m":34859742351.140373,
+    "geom:area_square_m":34859742351.149239,
     "geom:bbox":"174.313776,-39.300652,176.505325,-36.258285",
     "geom:latitude":-37.812827,
     "geom:longitude":175.437742,
@@ -323,12 +323,18 @@
         "gn:id":2180293,
         "gp:id":15021765,
         "hasc:id":"NZ.WK",
+        "iso:code":"NZ-WKO",
         "iso:id":"NZ-WKO",
+        "nz-linz:id":"03",
         "unlc:id":"NZ-WKO",
         "wd:id":"Q139918"
     },
+    "wof:concordances_official":"nz-linz:id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"NZ",
-    "wof:geomhash":"0f09e582ab0a0337df449d7dde893a03",
+    "wof:geomhash":"1c79cc82f695846e61f9f5eb7eb4364c",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -345,7 +351,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1690849930,
+    "wof:lastmodified":1695884461,
     "wof:name":"Waikato Region",
     "wof:parent_id":85633345,
     "wof:placetype":"region",

--- a/data/856/872/33/85687233.geojson
+++ b/data/856/872/33/85687233.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.710759,
-    "geom:area_square_m":15921702933.19817,
+    "geom:area_square_m":15921702933.199694,
     "geom:bbox":"174.388038,-41.815112,176.56406,-40.628591",
     "geom:latitude":-41.178263,
     "geom:longitude":175.416904,
@@ -409,12 +409,18 @@
         "gn:id":2179538,
         "gp:id":15021762,
         "hasc:id":"NZ.WG",
+        "iso:code":"NZ-WGN",
         "iso:id":"NZ-WGN",
+        "nz-linz:id":"09",
         "unlc:id":"NZ-WGN",
         "wd:id":"Q856010"
     },
+    "wof:concordances_official":"nz-linz:id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"NZ",
-    "wof:geomhash":"cd1f8bcf7e2dce2013c62fc4cd8ced55",
+    "wof:geomhash":"6b162468848d45314c78a436ab65b288",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -431,7 +437,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1690849929,
+    "wof:lastmodified":1695884461,
     "wof:name":"Wellington Region",
     "wof:parent_id":85633345,
     "wof:placetype":"region",

--- a/data/856/872/37/85687237.geojson
+++ b/data/856/872/37/85687237.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.433222,
-    "geom:area_square_m":13923035279.085007,
+    "geom:area_square_m":13923035279.10037,
     "geom:bbox":"177.122171,-39.001628,178.836208,-37.331372",
     "geom:latitude":-38.218822,
     "geom:longitude":178.113128,
@@ -154,10 +154,16 @@
         "gn:id":2190767,
         "gp:id":15021761,
         "hasc:id":"NZ.GI",
-        "iso:id":"NZ-GIS"
+        "iso:code":"NZ-GIS",
+        "iso:id":"NZ-GIS",
+        "nz-linz:id":"05"
     },
+    "wof:concordances_official":"nz-linz:id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"NZ",
-    "wof:geomhash":"5460e1a4bc2d8fdbd320c83b1c74c832",
+    "wof:geomhash":"eb4b850ab20cdddc4ab621ab3d9dd688",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -174,7 +180,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1607462738,
+    "wof:lastmodified":1695884461,
     "wof:name":"Gisborne Region",
     "wof:parent_id":85633345,
     "wof:placetype":"region",

--- a/data/856/872/43/85687243.geojson
+++ b/data/856/872/43/85687243.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.625514,
-    "geom:area_square_m":16152160918.001591,
+    "geom:area_square_m":16152160917.999199,
     "geom:bbox":"173.896631,-37.363454,175.9033,-35.698479",
     "geom:latitude":-36.522986,
     "geom:longitude":174.867371,
@@ -264,12 +264,18 @@
         "digitalenvoy:region_code":25041,
         "fips:code":"NZE7",
         "hasc:id":"NZ.AU",
+        "iso:code":"NZ-AUK",
         "iso:id":"NZ-AUK",
+        "nz-linz:id":"02",
         "unlc:id":"NZ-AUK",
         "wd:id":"Q18574960"
     },
+    "wof:concordances_official":"nz-linz:id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"NZ",
-    "wof:geomhash":"24416b8b071ee4d4fc04d68c2ded0370",
+    "wof:geomhash":"3b17592c505fd42630caecd9cd62e876",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -286,7 +292,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1690849931,
+    "wof:lastmodified":1695884462,
     "wof:name":"Auckland Region",
     "wof:parent_id":85633345,
     "wof:placetype":"region",

--- a/data/856/872/51/85687251.geojson
+++ b/data/856/872/51/85687251.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.663002,
-    "geom:area_square_m":25287149974.153816,
+    "geom:area_square_m":25287149974.150299,
     "geom:bbox":"174.675165,-40.81111,176.892079,-38.470329",
     "geom:latitude":-39.827003,
     "geom:longitude":175.556433,
@@ -315,12 +315,18 @@
         "gn:id":2179671,
         "gp:id":15021764,
         "hasc:id":"NZ.MW",
+        "iso:code":"NZ-MWT",
         "iso:id":"NZ-MWT",
+        "nz-linz:id":"08",
         "unlc:id":"NZ-MWT",
         "wd:id":"Q139907"
     },
+    "wof:concordances_official":"nz-linz:id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"NZ",
-    "wof:geomhash":"ae9348c243cfc8e97323a36181b8909c",
+    "wof:geomhash":"1a71704cae00a946e836a1753447d89a",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -337,7 +343,7 @@
         "eng",
         "mri"
     ],
-    "wof:lastmodified":1690849928,
+    "wof:lastmodified":1695884462,
     "wof:name":"Manawatu-Wanganui Region",
     "wof:parent_id":85633345,
     "wof:placetype":"region",


### PR DESCRIPTION
Will fix a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2164. Sets wof:concordances_official, wof:concordances_official_alt, and wof:label_*_x_preferred properties, and wof:concordances{*:*} hashes when approprirate.